### PR TITLE
Remove buildToolsVersion

### DIFF
--- a/Android/MMKV/build.gradle
+++ b/Android/MMKV/build.gradle
@@ -35,7 +35,6 @@ ext {
     minSdkVersion = 16
     compileSdkVersion = 28
     targetSdkVersion = compileSdkVersion
-    buildToolsVersion = '28.0.2'
     supportLibVersion = "25.4.0"
     javaVersion = JavaVersion.VERSION_1_7
 

--- a/Android/MMKV/gradle/build_library.gradle
+++ b/Android/MMKV/gradle/build_library.gradle
@@ -9,7 +9,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion

--- a/Android/MMKV/mmkv/src/main/cpp/InterProcessLock.h
+++ b/Android/MMKV/mmkv/src/main/cpp/InterProcessLock.h
@@ -33,7 +33,7 @@ enum LockType {
 // handles lock upgrade & downgrade correctly
 class FileLock {
     int m_fd;
-    flock m_lockInfo;
+    struct flock m_lockInfo;
     size_t m_sharedLockCount;
     size_t m_exclusiveLockCount;
 


### PR DESCRIPTION
Android studio 3.0 does not need to define buildToolsVersion, it can automatically apply the latest compiler tool version.