### PR TITLE
Small optimize by removing redundant code

### DIFF
--- a/iOS/MMKV/MMKV/MMKV.mm
+++ b/iOS/MMKV/MMKV/MMKV.mm
@@ -254,7 +254,7 @@ NSData *decryptBuffer(AESCrypt &crypter, NSData *inputBuffer) {
 						if (m_cryptor) {
 							inputBuffer = decryptBuffer(*m_cryptor, inputBuffer);
 						}
-						m_dic = [MiniPBCoder decodeContainerOfClass:NSDictionary.class withValueClass:NSData.class fromData:inputBuffer];
+						m_dic = [MiniPBCoder decodeContainerOfClass:NSMutableDictionary.class withValueClass:NSData.class fromData:inputBuffer];
 						m_output = new MiniCodedOutputData(m_ptr + offset + m_actualSize, m_size - offset - m_actualSize);
 					} else {
 						[self writeAcutalSize:0];

--- a/iOS/MMKV/MMKV/MMKV.mm
+++ b/iOS/MMKV/MMKV/MMKV.mm
@@ -69,13 +69,10 @@ static NSRecursiveLock *g_instanceLock;
 
 + (void)initialize {
 	if (self == MMKV.class) {
-		static dispatch_once_t onceToken;
-		dispatch_once(&onceToken, ^{
-			g_instanceDic = [NSMutableDictionary dictionary];
-			g_instanceLock = [[NSRecursiveLock alloc] init];
-
-			MMKVInfo(@"pagesize:%d", DEFAULT_MMAP_SIZE);
-		});
+		g_instanceDic = [NSMutableDictionary dictionary];
+		g_instanceLock = [[NSRecursiveLock alloc] init];
+		
+		MMKVInfo(@"pagesize:%d", DEFAULT_MMAP_SIZE);
 	}
 }
 
@@ -257,7 +254,7 @@ NSData *decryptBuffer(AESCrypt &crypter, NSData *inputBuffer) {
 						if (m_cryptor) {
 							inputBuffer = decryptBuffer(*m_cryptor, inputBuffer);
 						}
-						m_dic = [MiniPBCoder decodeContainerOfClass:NSMutableDictionary.class withValueClass:NSData.class fromData:inputBuffer];
+						m_dic = [MiniPBCoder decodeContainerOfClass:NSDictionary.class withValueClass:NSData.class fromData:inputBuffer];
 						m_output = new MiniCodedOutputData(m_ptr + offset + m_actualSize, m_size - offset - m_actualSize);
 					} else {
 						[self writeAcutalSize:0];

--- a/iOS/MMKV/MMKV/MiniPBCoder.mm
+++ b/iOS/MMKV/MMKV/MiniPBCoder.mm
@@ -292,7 +292,7 @@
 	id obj = nil;
 	@try {
 		MiniPBCoder *oCoder = [[MiniPBCoder alloc] initForReadingWithData:oData];
-		if (cls == [NSDictionary class] || cls == [NSMutableDictionary class]) {
+		if (cls == [NSMutableDictionary class] || cls == [NSDictionary class]) {
 			obj = [oCoder decodeOneDictionaryOfValueClass:valueClass];
 		} else {
 			MMKVError(@"%@ not recognized as container", NSStringFromClass(cls));


### PR DESCRIPTION
1. `initialize` already thread-safe, and only be called once by `self == MMKV.class` checking, so we can remove `dispatch_once_t` safely. 
2. `NSDictionary` may better.