### PR TITLE
iOS support custom folder

### DIFF
--- a/iOS/MMKV/MMKV/MMKV.h
+++ b/iOS/MMKV/MMKV/MMKV.h
@@ -36,6 +36,9 @@ NS_ASSUME_NONNULL_BEGIN
 // cryptKey: 16 byte at most
 + (nullable instancetype)mmkvWithID:(NSString *)mmapID cryptKey:(nullable NSData *)cryptKey NS_SWIFT_NAME(init(mmapID:cryptKey:));
 
++ (instancetype)mmkvWithID:(NSString *)mmapID relativePath:(nullable NSString *)path NS_SWIFT_NAME(init(mmapID:relativePath:));
++ (instancetype)mmkvWithID:(NSString *)mmapID cryptKey:(nullable NSData *)cryptKey relativePath:(nullable NSString *)path NS_SWIFT_NAME(init(mmapID:cryptKey:relativePath:));
+
 - (BOOL)reKey:(nullable NSData *)newKey NS_SWIFT_NAME(reset(cryptKey:));
 - (nullable NSData *)cryptKey;
 
@@ -98,6 +101,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (size_t)count;
 
 - (size_t)totalSize;
+
 - (size_t)actualSize;
 
 - (void)enumerateKeys:(void (^)(NSString *key, BOOL *stop))block;
@@ -127,6 +131,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 // for CrashProtected Only!!
 + (BOOL)isFileValid:(NSString *)mmapID NS_SWIFT_NAME(isFileValid(for:));
++ (BOOL)isFileValid:(NSString *)mmapID relativePath:(nullable NSString *)path NS_SWIFT_NAME(isFileValid(for:relativePath:));
 
 + (void)registerHandler:(id<MMKVHandler>)handler;
 + (void)unregiserHandler;

--- a/iOS/MMKV/MMKV/MMKV.h
+++ b/iOS/MMKV/MMKV/MMKV.h
@@ -98,6 +98,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (size_t)count;
 
 - (size_t)totalSize;
+- (size_t)actualSize;
 
 - (void)enumerateKeys:(void (^)(NSString *key, BOOL *stop))block;
 

--- a/iOS/MMKV/MMKV/MMKV.mm
+++ b/iOS/MMKV/MMKV/MMKV.mm
@@ -1218,6 +1218,12 @@ NSData *decryptBuffer(AESCrypt &crypter, NSData *inputBuffer) {
 	return m_size;
 }
 
+- (size_t)actualSize {
+    CScopedLock lock(m_lock);
+    [self checkLoadData];
+    return m_actualSize;
+}
+
 - (void)enumerateKeys:(void (^)(NSString *key, BOOL *stop))block {
 	if (block == nil) {
 		return;


### PR DESCRIPTION
1. add new init methods to support specifying custom folder relative path.
2. add new public class method to support validating file.
3. for custom folder, get hash string with its absolute path, then use hash string as kv key in global dictionary.
    for default path, keep origin workflow.