### PR TITLE
Fixed a line break format issue

### DIFF
--- a/iOS/MMKV/MMKV/MMKV.h
+++ b/iOS/MMKV/MMKV/MMKV.h
@@ -45,8 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 // if you want a per-user mmkv, you could merge user-id within mmapID
 // cryptKey: 16 byte at most
 // relativePath: custom path of the file, `NSDocumentDirectory/mmkv` by default
-+ (nullable instancetype)mmkvWithID:(NSString *)mmapID cryptKey:(nullable NSData *)cryptKey relativePath:(nullable NSString *)path NS_SWIFT_NAME(init(mmapID:cryptKey:relativePath
-:));
++ (nullable instancetype)mmkvWithID:(NSString *)mmapID cryptKey:(nullable NSData *)cryptKey relativePath:(nullable NSString *)path NS_SWIFT_NAME(init(mmapID:cryptKey:relativePath:));
 
 // default to `NSDocumentDirectory/mmkv`
 + (NSString *)mmkvBasePath;


### PR DESCRIPTION
This will cause `CF_SWIFT_NAME` warning from Swift Complier or SwiftLint.