### PR TITLE
In single-process mode, each process uses different files

### DIFF
--- a/Android/MMKV/mmkv/src/main/cpp/MMKV.cpp
+++ b/Android/MMKV/mmkv/src/main/cpp/MMKV.cpp
@@ -180,7 +180,7 @@ MMKV::~MMKV() {
 }
 
 MMKV *MMKV::defaultMMKV(MMKVMode mode, string *cryptKey) {
-    return mmkvWithID(DEFAULT_MMAP_ID, DEFAULT_MMAP_SIZE, mode, cryptKey);
+    return mmkvWithID(DEFAULT_MMAP_ID + to_string(getpid()), DEFAULT_MMAP_SIZE, mode, cryptKey);
 }
 
 void initialize() {

--- a/Android/MMKV/mmkv/src/main/java/com/tencent/mmkv/MMKV.java
+++ b/Android/MMKV/mmkv/src/main/java/com/tencent/mmkv/MMKV.java
@@ -27,6 +27,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.os.Process;
 import android.support.annotation.Nullable;
 import android.util.Log;
 
@@ -136,7 +137,8 @@ public class MMKV implements SharedPreferences, SharedPreferences.Editor {
             throw new IllegalStateException("You should Call MMKV.initialize() first.");
         }
 
-        long handle = getMMKVWithID(mmapID, SINGLE_PROCESS_MODE, null, null);
+        long handle = getMMKVWithID(getRealMmapID(mmapID, SINGLE_PROCESS_MODE),
+                SINGLE_PROCESS_MODE, null, null);
         return new MMKV(handle);
     }
 
@@ -145,7 +147,7 @@ public class MMKV implements SharedPreferences, SharedPreferences.Editor {
             throw new IllegalStateException("You should Call MMKV.initialize() first.");
         }
 
-        long handle = getMMKVWithID(mmapID, mode, null, null);
+        long handle = getMMKVWithID(getRealMmapID(mmapID, mode), mode, null, null);
         return new MMKV(handle);
     }
 
@@ -155,7 +157,7 @@ public class MMKV implements SharedPreferences, SharedPreferences.Editor {
             throw new IllegalStateException("You should Call MMKV.initialize() first.");
         }
 
-        long handle = getMMKVWithID(mmapID, mode, cryptKey, null);
+        long handle = getMMKVWithID(getRealMmapID(mmapID, mode), mode, cryptKey, null);
         return new MMKV(handle);
     }
 
@@ -165,7 +167,8 @@ public class MMKV implements SharedPreferences, SharedPreferences.Editor {
             throw new IllegalStateException("You should Call MMKV.initialize() first.");
         }
 
-        long handle = getMMKVWithID(mmapID, SINGLE_PROCESS_MODE, null, relativePath);
+        long handle = getMMKVWithID(getRealMmapID(mmapID, SINGLE_PROCESS_MODE),
+                SINGLE_PROCESS_MODE, null, relativePath);
         if (handle == 0) {
             return null;
         }
@@ -179,11 +182,22 @@ public class MMKV implements SharedPreferences, SharedPreferences.Editor {
             throw new IllegalStateException("You should Call MMKV.initialize() first.");
         }
 
-        long handle = getMMKVWithID(mmapID, mode, cryptKey, relativePath);
+        long handle = getMMKVWithID(getRealMmapID(mmapID, mode), mode, cryptKey, relativePath);
         if (handle == 0) {
             return null;
         }
         return new MMKV(handle);
+    }
+
+    private static String getRealMmapID(String mmapID, int mode) {
+        switch (mode) {
+            case SINGLE_PROCESS_MODE:
+                return mmapID + Process.myPid();
+            case MULTI_PROCESS_MODE:
+                return mmapID;
+            default:
+                return mmapID;
+        }
     }
 
     // a memory only MMKV, cleared on program exit


### PR DESCRIPTION
I found a problem in my project that if multi processes use the same mmap_ID and write data in a single process mode, there will be a CRC verification failure problem, as shown in the following picture. This problem can be solved by distinguishing map files in single-process mode.
![image](https://user-images.githubusercontent.com/26972807/54026837-405ca480-41da-11e9-9d97-ecc1033bb208.png)
