### PR TITLE
改为flock，避免错误的死锁检测导致的锁失败

### DIFF
--- a/Android/MMKV/mmkv/src/main/cpp/InterProcessLock.cpp
+++ b/Android/MMKV/mmkv/src/main/cpp/InterProcessLock.cpp
@@ -21,25 +21,23 @@
 #include "InterProcessLock.h"
 #include "MMKVLog.h"
 #include <unistd.h>
+#include <sys/file.h>
 
 static short LockType2FlockType(LockType lockType) {
     switch (lockType) {
         case SharedLockType:
-            return F_RDLCK;
+            return LOCK_SH;
         case ExclusiveLockType:
-            return F_WRLCK;
+            return LOCK_EX;
     }
+    return LOCK_EX;
 }
 
 FileLock::FileLock(int fd) : m_fd(fd), m_sharedLockCount(0), m_exclusiveLockCount(0) {
-    m_lockInfo.l_type = F_WRLCK;
-    m_lockInfo.l_start = 0;
-    m_lockInfo.l_whence = SEEK_SET;
-    m_lockInfo.l_len = 0;
-    m_lockInfo.l_pid = 0;
+
 }
 
-bool FileLock::doLock(LockType lockType, int cmd) {
+bool FileLock::doLock(LockType lockType, bool wait) {
     if (!isFileLockValid()) {
         return false;
     }
@@ -63,25 +61,23 @@ bool FileLock::doLock(LockType lockType, int cmd) {
         }
     }
 
-    m_lockInfo.l_type = LockType2FlockType(lockType);
+    int realLockType = LockType2FlockType(lockType);
+    int cmd = wait ? realLockType : (realLockType | LOCK_NB);
     if (unLockFirstIfNeeded) {
         // try lock
-        auto ret = fcntl(m_fd, F_SETLK, &m_lockInfo);
+        auto ret = flock(m_fd, realLockType | LOCK_NB);
         if (ret == 0) {
             return true;
         }
         // lets be gentleman: unlock my shared-lock to prevent deadlock
-        auto type = m_lockInfo.l_type;
-        m_lockInfo.l_type = F_UNLCK;
-        ret = fcntl(m_fd, F_SETLK, &m_lockInfo);
+        ret = flock(m_fd, LOCK_UN);
         if (ret != 0) {
             MMKVError("fail to try unlock first fd=%d, ret=%d, error:%s", m_fd, ret,
                       strerror(errno));
         }
-        m_lockInfo.l_type = type;
     }
 
-    auto ret = fcntl(m_fd, cmd, &m_lockInfo);
+    auto ret = flock(m_fd, cmd);
     if (ret != 0) {
         MMKVError("fail to lock fd=%d, ret=%d, error:%s", m_fd, ret, strerror(errno));
         return false;
@@ -91,11 +87,11 @@ bool FileLock::doLock(LockType lockType, int cmd) {
 }
 
 bool FileLock::lock(LockType lockType) {
-    return doLock(lockType, F_SETLKW);
+    return doLock(lockType, true);
 }
 
 bool FileLock::try_lock(LockType lockType) {
-    return doLock(lockType, F_SETLK);
+    return doLock(lockType, false);
 }
 
 bool FileLock::unlock(LockType lockType) {
@@ -127,8 +123,8 @@ bool FileLock::unlock(LockType lockType) {
         }
     }
 
-    m_lockInfo.l_type = static_cast<short>(unlockToSharedLock ? F_RDLCK : F_UNLCK);
-    auto ret = fcntl(m_fd, F_SETLK, &m_lockInfo);
+    int cmd = static_cast<short>(unlockToSharedLock ? LOCK_SH : LOCK_UN);
+    auto ret = flock(m_fd, cmd);
     if (ret != 0) {
         MMKVError("fail to unlock fd=%d, ret=%d, error:%s", m_fd, ret, strerror(errno));
         return false;

--- a/Android/MMKV/mmkv/src/main/cpp/InterProcessLock.h
+++ b/Android/MMKV/mmkv/src/main/cpp/InterProcessLock.h
@@ -33,11 +33,10 @@ enum LockType {
 // handles lock upgrade & downgrade correctly
 class FileLock {
     int m_fd;
-    struct flock m_lockInfo;
     size_t m_sharedLockCount;
     size_t m_exclusiveLockCount;
 
-    bool doLock(LockType lockType, int cmd);
+    bool doLock(LockType lockType, bool wait);
 
     bool isFileLockValid() { return m_fd >= 0; }
 
@@ -62,7 +61,7 @@ class InterProcessLock {
 
 public:
     InterProcessLock(FileLock *fileLock, LockType lockType)
-        : m_fileLock(fileLock), m_lockType(lockType), m_enable(true) {
+            : m_fileLock(fileLock), m_lockType(lockType), m_enable(true) {
         assert(m_fileLock);
     }
 


### PR DESCRIPTION
请参考下面的链接：
http://man7.org/linux/man-pages/man2/fcntl.2.html
Bugs
   Deadlock detection
       The deadlock-detection algorithm employed by the kernel when dealing
       with F_SETLKW requests can yield both false negatives (failures to
       detect deadlocks, leaving a set of deadlocked processes blocked
       indefinitely) and false positives (EDEADLK errors when there is no
       deadlock).  For example, the kernel limits the lock depth of its
       dependency search to 10 steps, meaning that circular deadlock chains
       that exceed that size will not be detected.  In addition, the kernel
       may falsely indicate a deadlock when two or more processes created
       using the clone(2) CLONE_FILES flag place locks that appear (to the
       kernel) to conflict.