### PR TITLE
enable unwind-tables and add add memcpy's error log

### DIFF
--- a/Android/MMKV/mmkv/build.gradle
+++ b/Android/MMKV/mmkv/build.gradle
@@ -19,7 +19,7 @@ android {
             minifyEnabled false
             externalNativeBuild {
                 cmake {
-                    cppFlags "-fvisibility=hidden", "-fno-unwind-tables", "-fno-asynchronous-unwind-tables"
+                    cppFlags "-fvisibility=hidden", "-funwind-tables", "-fasynchronous-unwind-tables"
                 }
             }
             consumerProguardFiles 'proguard-rules.pro'

--- a/Android/MMKV/mmkv/src/main/cpp/CodedOutputData.cpp
+++ b/Android/MMKV/mmkv/src/main/cpp/CodedOutputData.cpp
@@ -60,6 +60,10 @@ void CodedOutputData::writeBool(bool value) {
 
 void CodedOutputData::writeString(const string &value) {
     size_t numberOfBytes = value.size();
+    if (m_position + numberOfBytes > m_size) {
+        MMKVError("m_position: %d, numberOfBytes: %zd, m_size: %zd", m_position, numberOfBytes,
+                  m_size);
+    }
     this->writeRawVarint32((int32_t) numberOfBytes);
     memcpy(m_ptr + m_position, ((uint8_t *) value.data()), numberOfBytes);
     m_position += numberOfBytes;
@@ -93,6 +97,10 @@ void CodedOutputData::writeRawByte(uint8_t value) {
 
 void CodedOutputData::writeRawData(const MMBuffer &data) {
     size_t numberOfBytes = data.length();
+    if (m_position + numberOfBytes > m_size) {
+        MMKVError("m_position: %d, numberOfBytes: %zd, m_size: %zd", m_position, numberOfBytes,
+                  m_size);
+    }
     memcpy(m_ptr + m_position, data.getPtr(), numberOfBytes);
     m_position += numberOfBytes;
 }


### PR DESCRIPTION
I think the stacktrace is a very important for a opensource project.
I add the log for the memcpy crash and enable the gcc flag:unwind-tables