### PR TITLE
Fix Rebuild from Bitcode fails on watchOS

### DIFF
--- a/MMKVCore.podspec
+++ b/MMKVCore.podspec
@@ -19,7 +19,11 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = "2.0"
 
   s.source       = { :git => "https://github.com/Tencent/MMKV.git", :tag => "v#{s.version}" }
-  s.source_files = "Core", "Core/*.{h,cpp,hpp}", "Core/aes/*", "Core/aes/openssl/*", "Core/crc32/*.h"
+  s.source_files = "Core/*.{h,cpp,hpp}", "Core/aes/*.{h,cpp}", "Core/aes/openssl/*.{h,cpp}", "Core/crc32/*.h"
+
+  s.ios.source_files =  "Core/aes/openssl/*.S"
+  s.osx.source_files = "Core/aes/openssl/*.S"
+
   s.public_header_files = "Core/MMBuffer.h", "Core/MMKV.h", "Core/MMKVLog.h", "Core/MMKVPredef.h", "Core/PBUtility.h", "Core/ScopedLock.hpp", "Core/ThreadLock.h", "Core/aes/openssl/openssl_md5.h", "Core/aes/openssl/openssl_opensslconf.h"
   s.compiler_flags = '-x objective-c++'
 
@@ -33,6 +37,11 @@ Pod::Spec.new do |s|
     "CLANG_CXX_LIBRARY" => "libc++",
     "CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF" => "NO",
   }
+  s.watchos.pod_target_xcconfig = {
+    'GCC_PREPROCESSOR_DEFINITIONS' => 'MMKV_DISABLE_CRYPT=1',
+    'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '\$(inherited) MMKV_DISABLE_CRYPT'
+}
+
 
 end
 

--- a/iOS/MMKV/MMKV/libMMKV.mm
+++ b/iOS/MMKV/MMKV/libMMKV.mm
@@ -290,7 +290,7 @@ static BOOL g_hasCalledInitializeMMKV = NO;
 
 #pragma mark - encryption & decryption
 
-#ifndef MMKV_DISABLE_CRYPT
+#if !defined(MMKV_DISABLE_CRYPT) && !TARGET_OS_WATCH
 
 - (nullable NSData *)cryptKey {
     auto str = m_mmkv->cryptKey();


### PR DESCRIPTION
### Description
- When linking a watchOS app with MMKVCore, the app compiles and runs successfully. But failing when rebuild from Bitcode (required for App Store release).
- Issue posted here: https://github.com/Tencent/MMKV/issues/749 

### Changes
- Remove 'S' files for Watch's source files in Podspec.
- Temporary disable `MMKV_DISABLE_CRYPT` to fix the errors after removing 'S' files