### PR TITLE
Fix crash when using Ashmem with multi-process when MMKV_DISABLE_CRYPT defined

### DIFF
--- a/Android/MMKV/mmkv/src/main/cpp/native-bridge.cpp
+++ b/Android/MMKV/mmkv/src/main/cpp/native-bridge.cpp
@@ -712,6 +712,12 @@ MMKV_JNI void checkReSetCryptKey(JNIEnv *env, jobject instance, jstring cryptKey
     }
 }
 
+#    else
+
+MMKV_JNI jstring cryptKey(JNIEnv *env, jobject instance) {
+    return nullptr;
+}
+
 #    endif // MMKV_DISABLE_CRYPT
 
 MMKV_JNI void trim(JNIEnv *env, jobject instance) {
@@ -841,8 +847,8 @@ MMKV_JNI jlong restoreAll(JNIEnv *env, jobject obj, jstring srcDir/*, jstring ro
 
 static JNINativeMethod g_methods[] = {
     {"onExit", "()V", (void *) mmkv::onExit},
-#    ifndef MMKV_DISABLE_CRYPT
     {"cryptKey", "()Ljava/lang/String;", (void *) mmkv::cryptKey},
+#    ifndef MMKV_DISABLE_CRYPT
     {"reKey", "(Ljava/lang/String;)Z", (void *) mmkv::reKey},
     {"checkReSetCryptKey", "(Ljava/lang/String;)V", (void *) mmkv::checkReSetCryptKey},
 #    endif


### PR DESCRIPTION
When `MMKV_DISABLE_CRYPT` is defined, still generate the method cryptKey but always returns nullptr to solve this crash.

**Platform:** Android

**More:**
In this part, `new ParcelableMMKV(mmkv)` has been used.
> 
    private Bundle mmkvFromAshmemID(String ashmemID, int size, int mode, String cryptKey) throws RuntimeException {
        MMKV mmkv = MMKV.mmkvWithAshmemID(this.getContext(), ashmemID, size, mode, cryptKey);
        ParcelableMMKV parcelableMMKV = new ParcelableMMKV(mmkv);
        Log.i("MMKV", ashmemID + " fd = " + mmkv.ashmemFD() + ", meta fd = " + mmkv.ashmemMetaFD());
        Bundle result = new Bundle();
        result.putParcelable("KEY", parcelableMMKV);
        return result;
    }

This line `this.cryptKey = mmkv.cryptKey();` causes the crash.
> 
    public ParcelableMMKV(MMKV mmkv) {
        this.ashmemFD = -1;
        this.ashmemMetaFD = -1;
        this.cryptKey = null;
        this.mmapID = mmkv.mmapID();
        this.ashmemFD = mmkv.ashmemFD();
        this.ashmemMetaFD = mmkv.ashmemMetaFD();
        this.cryptKey = mmkv.cryptKey();
    }