### PR TITLE
feat: Implement `hasValue` OUT parameter for iOS

### DIFF
--- a/iOS/MMKV/MMKV/MMKV.h
+++ b/iOS/MMKV/MMKV/MMKV.h
@@ -20,6 +20,8 @@
 
 #import "MMKVHandler.h"
 
+#define OUT
+
 typedef NS_ENUM(NSUInteger, MMKVMode) {
     MMKVSingleProcess = 0x1,
     MMKVMultiProcess = 0x2,
@@ -133,33 +135,43 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)getBoolForKey:(NSString *)key __attribute__((swift_name("bool(forKey:)")));
 - (BOOL)getBoolForKey:(NSString *)key defaultValue:(BOOL)defaultValue __attribute__((swift_name("bool(forKey:defaultValue:)")));
+- (BOOL)getBoolForKey:(NSString *)key defaultValue:(BOOL)defaultValue hasValue:(OUT BOOL *)hasValue __attribute__((swift_name("bool(forKey:defaultValue:hasValue:)")));
 
 - (int32_t)getInt32ForKey:(NSString *)key NS_SWIFT_NAME(int32(forKey:));
 - (int32_t)getInt32ForKey:(NSString *)key defaultValue:(int32_t)defaultValue NS_SWIFT_NAME(int32(forKey:defaultValue:));
+- (int32_t)getInt32ForKey:(NSString *)key defaultValue:(int32_t)defaultValue hasValue:(OUT BOOL *)hasValue NS_SWIFT_NAME(int32(forKey:defaultValue:hasValue:));
 
 - (uint32_t)getUInt32ForKey:(NSString *)key NS_SWIFT_NAME(uint32(forKey:));
 - (uint32_t)getUInt32ForKey:(NSString *)key defaultValue:(uint32_t)defaultValue NS_SWIFT_NAME(uint32(forKey:defaultValue:));
+- (uint32_t)getUInt32ForKey:(NSString *)key defaultValue:(uint32_t)defaultValue hasValue:(OUT BOOL *)hasValue NS_SWIFT_NAME(uint32(forKey:defaultValue:hasValue:));
 
 - (int64_t)getInt64ForKey:(NSString *)key NS_SWIFT_NAME(int64(forKey:));
 - (int64_t)getInt64ForKey:(NSString *)key defaultValue:(int64_t)defaultValue NS_SWIFT_NAME(int64(forKey:defaultValue:));
+- (int64_t)getInt64ForKey:(NSString *)key defaultValue:(int64_t)defaultValue hasValue:(OUT BOOL *)hasValue NS_SWIFT_NAME(int64(forKey:defaultValue:hasValue:));
 
 - (uint64_t)getUInt64ForKey:(NSString *)key NS_SWIFT_NAME(uint64(forKey:));
 - (uint64_t)getUInt64ForKey:(NSString *)key defaultValue:(uint64_t)defaultValue NS_SWIFT_NAME(uint64(forKey:defaultValue:));
+- (uint64_t)getUInt64ForKey:(NSString *)key defaultValue:(uint64_t)defaultValue hasValue:(OUT BOOL *)hasValue NS_SWIFT_NAME(uint64(forKey:defaultValue:hasValue:));
 
 - (float)getFloatForKey:(NSString *)key NS_SWIFT_NAME(float(forKey:));
 - (float)getFloatForKey:(NSString *)key defaultValue:(float)defaultValue NS_SWIFT_NAME(float(forKey:defaultValue:));
+- (float)getFloatForKey:(NSString *)key defaultValue:(float)defaultValue hasValue:(OUT BOOL *)hasValue NS_SWIFT_NAME(float(forKey:defaultValue:hasValue:));
 
 - (double)getDoubleForKey:(NSString *)key NS_SWIFT_NAME(double(forKey:));
 - (double)getDoubleForKey:(NSString *)key defaultValue:(double)defaultValue NS_SWIFT_NAME(double(forKey:defaultValue:));
+- (double)getDoubleForKey:(NSString *)key defaultValue:(double)defaultValue hasValue:(OUT BOOL *)hasValue NS_SWIFT_NAME(double(forKey:defaultValue:hasValue:));
 
 - (nullable NSString *)getStringForKey:(NSString *)key NS_SWIFT_NAME(string(forKey:));
 - (nullable NSString *)getStringForKey:(NSString *)key defaultValue:(nullable NSString *)defaultValue NS_SWIFT_NAME(string(forKey:defaultValue:));
+- (nullable NSString *)getStringForKey:(NSString *)key defaultValue:(nullable NSString *)defaultValue hasValue:(OUT BOOL *)hasValue NS_SWIFT_NAME(string(forKey:defaultValue:hasValue:));
 
 - (nullable NSDate *)getDateForKey:(NSString *)key NS_SWIFT_NAME(date(forKey:));
 - (nullable NSDate *)getDateForKey:(NSString *)key defaultValue:(nullable NSDate *)defaultValue NS_SWIFT_NAME(date(forKey:defaultValue:));
+- (nullable NSDate *)getDateForKey:(NSString *)key defaultValue:(nullable NSDate *)defaultValue hasValue:(OUT BOOL *)hasValue NS_SWIFT_NAME(date(forKey:defaultValue:hasValue:));
 
 - (nullable NSData *)getDataForKey:(NSString *)key NS_SWIFT_NAME(data(forKey:));
 - (nullable NSData *)getDataForKey:(NSString *)key defaultValue:(nullable NSData *)defaultValue NS_SWIFT_NAME(data(forKey:defaultValue:));
+- (nullable NSData *)getDataForKey:(NSString *)key defaultValue:(nullable NSData *)defaultValue hasValue:(OUT BOOL *)hasValue NS_SWIFT_NAME(data(forKey:defaultValue:hasValue:));
 
 // return the actual size consumption of the key's value
 // Note: might be a little bigger than value's length

--- a/iOS/MMKV/MMKV/libMMKV.mm
+++ b/iOS/MMKV/MMKV/libMMKV.mm
@@ -383,7 +383,7 @@ static BOOL g_hasCalledInitializeMMKV = NO;
 }
 
 - (BOOL)getBoolForKey:(NSString *)key {
-    return [self getBoolForKey:key defaultValue:FALSE];
+    return [self getBoolForKey:key defaultValue:FALSE hasValue:nil];
 }
 - (BOOL)getBoolForKey:(NSString *)key defaultValue:(BOOL)defaultValue {
     return [self getBoolForKey:key defaultValue:defaultValue hasValue:nil];
@@ -393,17 +393,17 @@ static BOOL g_hasCalledInitializeMMKV = NO;
 }
 
 - (int32_t)getInt32ForKey:(NSString *)key {
-    return [self getInt32ForKey:key defaultValue:0];
+    return [self getInt32ForKey:key defaultValue:0 hasValue:nil];
 }
 - (int32_t)getInt32ForKey:(NSString *)key defaultValue:(int32_t)defaultValue {
-    return m_mmkv->getInt32(key, defaultValue);
+    return [self getInt32ForKey:key defaultValue:defaultValue hasValue:nil];
 }
 - (int32_t)getInt32ForKey:(NSString *)key defaultValue:(int32_t)defaultValue hasValue:(OUT BOOL *)hasValue {
     return m_mmkv->getInt32(key, defaultValue, hasValue);
 }
 
 - (uint32_t)getUInt32ForKey:(NSString *)key {
-    return [self getUInt32ForKey:key defaultValue:0];
+    return [self getUInt32ForKey:key defaultValue:0 hasValue:nil];
 }
 - (uint32_t)getUInt32ForKey:(NSString *)key defaultValue:(uint32_t)defaultValue {
     return [self getUInt32ForKey:key defaultValue:defaultValue hasValue:nil];
@@ -413,7 +413,7 @@ static BOOL g_hasCalledInitializeMMKV = NO;
 }
 
 - (int64_t)getInt64ForKey:(NSString *)key {
-    return [self getInt64ForKey:key defaultValue:0];
+    return [self getInt64ForKey:key defaultValue:0 hasValue:nil];
 }
 - (int64_t)getInt64ForKey:(NSString *)key defaultValue:(int64_t)defaultValue {
     return [self getInt64ForKey:key defaultValue:defaultValue hasValue:nil];
@@ -423,7 +423,7 @@ static BOOL g_hasCalledInitializeMMKV = NO;
 }
 
 - (uint64_t)getUInt64ForKey:(NSString *)key {
-    return [self getUInt64ForKey:key defaultValue:0];
+    return [self getUInt64ForKey:key defaultValue:0 hasValue:nil];
 }
 - (uint64_t)getUInt64ForKey:(NSString *)key defaultValue:(uint64_t)defaultValue {
     return [self getUInt64ForKey:key defaultValue:defaultValue hasValue:nil];
@@ -433,7 +433,7 @@ static BOOL g_hasCalledInitializeMMKV = NO;
 }
 
 - (float)getFloatForKey:(NSString *)key {
-    return [self getFloatForKey:key defaultValue:0];
+    return [self getFloatForKey:key defaultValue:0 hasValue:nil];
 }
 - (float)getFloatForKey:(NSString *)key defaultValue:(float)defaultValue {
     return [self getFloatForKey:key defaultValue:defaultValue hasValue:nil];
@@ -443,7 +443,7 @@ static BOOL g_hasCalledInitializeMMKV = NO;
 }
 
 - (double)getDoubleForKey:(NSString *)key {
-    return [self getDoubleForKey:key defaultValue:0];
+    return [self getDoubleForKey:key defaultValue:0 hasValue:nil];
 }
 - (double)getDoubleForKey:(NSString *)key defaultValue:(double)defaultValue {
     return [self getDoubleForKey:key defaultValue:defaultValue hasValue:nil];
@@ -453,7 +453,7 @@ static BOOL g_hasCalledInitializeMMKV = NO;
 }
 
 - (nullable NSString *)getStringForKey:(NSString *)key {
-    return [self getStringForKey:key defaultValue:nil];
+    return [self getStringForKey:key defaultValue:nil hasValue:nil];
 }
 - (nullable NSString *)getStringForKey:(NSString *)key defaultValue:(nullable NSString *)defaultValue {
     return [self getStringForKey:key defaultValue:defaultValue hasValue:nil];
@@ -473,7 +473,7 @@ static BOOL g_hasCalledInitializeMMKV = NO;
 }
 
 - (nullable NSDate *)getDateForKey:(NSString *)key {
-    return [self getDateForKey:key defaultValue:nil];
+    return [self getDateForKey:key defaultValue:nil hasValue:nil];
 }
 - (nullable NSDate *)getDateForKey:(NSString *)key defaultValue:(nullable NSDate *)defaultValue {
     return [self getDateForKey:key defaultValue:defaultValue hasValue:nil];

--- a/iOS/MMKV/MMKV/libMMKV.mm
+++ b/iOS/MMKV/MMKV/libMMKV.mm
@@ -386,7 +386,10 @@ static BOOL g_hasCalledInitializeMMKV = NO;
     return [self getBoolForKey:key defaultValue:FALSE];
 }
 - (BOOL)getBoolForKey:(NSString *)key defaultValue:(BOOL)defaultValue {
-    return m_mmkv->getBool(key, defaultValue);
+    return [self getBoolForKey:key defaultValue:defaultValue hasValue:nil];
+}
+- (BOOL)getBoolForKey:(NSString *)key defaultValue:(BOOL)defaultValue hasValue:(OUT BOOL *)hasValue {
+    return m_mmkv->getBool(key, defaultValue, hasValue);
 }
 
 - (int32_t)getInt32ForKey:(NSString *)key {
@@ -395,51 +398,75 @@ static BOOL g_hasCalledInitializeMMKV = NO;
 - (int32_t)getInt32ForKey:(NSString *)key defaultValue:(int32_t)defaultValue {
     return m_mmkv->getInt32(key, defaultValue);
 }
+- (int32_t)getInt32ForKey:(NSString *)key defaultValue:(int32_t)defaultValue hasValue:(OUT BOOL *)hasValue {
+    return m_mmkv->getInt32(key, defaultValue, hasValue);
+}
 
 - (uint32_t)getUInt32ForKey:(NSString *)key {
     return [self getUInt32ForKey:key defaultValue:0];
 }
 - (uint32_t)getUInt32ForKey:(NSString *)key defaultValue:(uint32_t)defaultValue {
-    return m_mmkv->getUInt32(key, defaultValue);
+    return [self getUInt32ForKey:key defaultValue:defaultValue hasValue:nil];
+}
+- (uint32_t)getUInt32ForKey:(NSString *)key defaultValue:(uint32_t)defaultValue hasValue:(OUT BOOL *)hasValue {
+    return m_mmkv->getUInt32(key, defaultValue, hasValue);
 }
 
 - (int64_t)getInt64ForKey:(NSString *)key {
     return [self getInt64ForKey:key defaultValue:0];
 }
 - (int64_t)getInt64ForKey:(NSString *)key defaultValue:(int64_t)defaultValue {
-    return m_mmkv->getInt64(key, defaultValue);
+    return [self getInt64ForKey:key defaultValue:defaultValue hasValue:nil];
+}
+- (int64_t)getInt64ForKey:(NSString *)key defaultValue:(int64_t)defaultValue hasValue:(OUT BOOL *)hasValue {
+    return m_mmkv->getInt64(key, defaultValue, hasValue);
 }
 
 - (uint64_t)getUInt64ForKey:(NSString *)key {
     return [self getUInt64ForKey:key defaultValue:0];
 }
 - (uint64_t)getUInt64ForKey:(NSString *)key defaultValue:(uint64_t)defaultValue {
-    return m_mmkv->getUInt64(key, defaultValue);
+    return [self getUInt64ForKey:key defaultValue:defaultValue hasValue:nil];
+}
+- (uint64_t)getUInt64ForKey:(NSString *)key defaultValue:(uint64_t)defaultValue hasValue:(OUT BOOL *)hasValue {
+    return m_mmkv->getUInt64(key, defaultValue, hasValue);
 }
 
 - (float)getFloatForKey:(NSString *)key {
     return [self getFloatForKey:key defaultValue:0];
 }
 - (float)getFloatForKey:(NSString *)key defaultValue:(float)defaultValue {
-    return m_mmkv->getFloat(key, defaultValue);
+    return [self getFloatForKey:key defaultValue:defaultValue hasValue:nil];
+}
+- (float)getFloatForKey:(NSString *)key defaultValue:(float)defaultValue hasValue:(OUT BOOL *)hasValue {
+    return m_mmkv->getFloat(key, defaultValue, hasValue);
 }
 
 - (double)getDoubleForKey:(NSString *)key {
     return [self getDoubleForKey:key defaultValue:0];
 }
 - (double)getDoubleForKey:(NSString *)key defaultValue:(double)defaultValue {
-    return m_mmkv->getDouble(key, defaultValue);
+    return [self getDoubleForKey:key defaultValue:defaultValue hasValue:nil];
+}
+- (double)getDoubleForKey:(NSString *)key defaultValue:(double)defaultValue hasValue:(OUT BOOL *)hasValue {
+    return m_mmkv->getDouble(key, defaultValue, hasValue);
 }
 
 - (nullable NSString *)getStringForKey:(NSString *)key {
     return [self getStringForKey:key defaultValue:nil];
 }
 - (nullable NSString *)getStringForKey:(NSString *)key defaultValue:(nullable NSString *)defaultValue {
+    return [self getStringForKey:key defaultValue:defaultValue hasValue:nil];
+}
+- (nullable NSString *)getStringForKey:(NSString *)key defaultValue:(nullable NSString *)defaultValue hasValue:(OUT BOOL *)hasValue {
     if (key.length <= 0) {
         return defaultValue;
     }
     NSString *valueString = [self getObjectOfClass:NSString.class forKey:key];
     if (!valueString) {
+        if (hasValue != nil) {
+            *hasValue = false;
+        }
         valueString = defaultValue;
     }
     return valueString;
@@ -449,11 +476,17 @@ static BOOL g_hasCalledInitializeMMKV = NO;
     return [self getDateForKey:key defaultValue:nil];
 }
 - (nullable NSDate *)getDateForKey:(NSString *)key defaultValue:(nullable NSDate *)defaultValue {
+    return [self getDateForKey:key defaultValue:defaultValue hasValue:nil];
+}
+- (nullable NSDate *)getDateForKey:(NSString *)key defaultValue:(nullable NSDate *)defaultValue hasValue:(OUT BOOL *)hasValue {
     if (key.length <= 0) {
         return defaultValue;
     }
     NSDate *valueDate = [self getObjectOfClass:NSDate.class forKey:key];
     if (!valueDate) {
+        if (hasValue != nil) {
+            *hasValue = false;
+        }
         valueDate = defaultValue;
     }
     return valueDate;
@@ -463,11 +496,17 @@ static BOOL g_hasCalledInitializeMMKV = NO;
     return [self getDataForKey:key defaultValue:nil];
 }
 - (nullable NSData *)getDataForKey:(NSString *)key defaultValue:(nullable NSData *)defaultValue {
+    return [self getDataForKey:key defaultValue:defaultValue hasValue:nil];
+}
+- (nullable NSData *)getDataForKey:(NSString *)key defaultValue:(nullable NSData *)defaultValue hasValue:(OUT BOOL *)hasValue {
     if (key.length <= 0) {
         return defaultValue;
     }
     NSData *valueData = [self getObjectOfClass:NSData.class forKey:key];
     if (!valueData) {
+        if (hasValue != nil) {
+            *hasValue = false;
+        }
         valueData = defaultValue;
     }
     return valueData;


### PR DESCRIPTION
Follow-up PR of #828 to implement the OUT parameter for iOS as well.

I specifically did not implement the `hasValue` OUT parameter for Android (yet), because
1. I do not need it for Android myself
2. On Android you cannot pass pointers/booleans by reference. We would have to introduce a new class which holds a boolean reference, and I am not sure if this is something that we want to support? cc @lingol 