### PR TITLE
Add basic XCFramework Support (SPM binary target support)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ dist/
 
 #Android Studio
 .cxx
+archives

--- a/iOS/archive_xcframework.sh
+++ b/iOS/archive_xcframework.sh
@@ -32,6 +32,8 @@ xcodebuild \
 -create-xcframework \
 -framework archives/MMKV-iOS.xcarchive/Products/Library/Frameworks/MMKV.framework \
 -debug-symbols $PWD/archives/MMKV-iOS.xcarchive/dSYMs/MMKV.framework.dSYM \
+-debug-symbols $PWD/archives/MMKV-iOS.xcarchive/BCSymbolMaps/0909AADB-3F01-3418-B7F2-E2B9FB6E315F.bcsymbolmap \
+-debug-symbols $PWD/archives/MMKV-iOS.xcarchive/BCSymbolMaps/441383DA-0478-34F4-9A38-F2521EB5B045.bcsymbolmap \
 -framework archives/MMKV-iOS-Simulator.xcarchive/Products/Library/Frameworks/MMKV.framework \
 -debug-symbols $PWD/archives/MMKV-iOS-Simulator.xcarchive/dSYMs/MMKV.framework.dSYM \
 -framework archives/MMKV-macOS.xcarchive/Products/Library/Frameworks/MMKV.framework \

--- a/iOS/archive_xcframework.sh
+++ b/iOS/archive_xcframework.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+rm -rf archives
+xcodebuild archive \
+-workspace MMKV.xcworkspace \
+-scheme MMKV \
+-configuration Release \
+-destination "generic/platform=iOS" \
+-archivePath "archives/MMKV-iOS" \
+SKIP_INSTALL=NO \
+BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+
+xcodebuild archive \
+-workspace MMKV.xcworkspace \
+-scheme MMKV \
+-configuration Release \
+-destination "generic/platform=iOS Simulator" \
+-archivePath "archives/MMKV-iOS-Simulator" \
+SKIP_INSTALL=NO \
+BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+
+xcodebuild archive \
+-workspace MMKV.xcworkspace \
+-scheme MMKV \
+-configuration Release \
+-destination "generic/platform=macOS" \
+-archivePath "archives/MMKV-macOS" \
+SKIP_INSTALL=NO \
+BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+
+xcodebuild \
+-create-xcframework \
+-framework archives/MMKV-iOS.xcarchive/Products/Library/Frameworks/MMKV.framework \
+-debug-symbols $PWD/archives/MMKV-iOS.xcarchive/dSYMs/MMKV.framework.dSYM \
+-framework archives/MMKV-iOS-Simulator.xcarchive/Products/Library/Frameworks/MMKV.framework \
+-debug-symbols $PWD/archives/MMKV-iOS-Simulator.xcarchive/dSYMs/MMKV.framework.dSYM \
+-framework archives/MMKV-macOS.xcarchive/Products/Library/Frameworks/MMKV.framework \
+-debug-symbols $PWD/archives/MMKV-macOS.xcarchive/dSYMs/MMKV.framework.dSYM \
+-output archives/MMKV.xcframework


### PR DESCRIPTION
Currently it is not easy to add source package for Swift Package Manager support.

But we can build and release it as a xcframework and use it as a binary target to support SPM.

Currently there are 2 ways to do it:
1. Add the binaryTarget directly in the Package.swift
```swift
// MMKVDemo
let package = Package(
    name: "MMKVDemo",
    products: [
        .library(name: "MMKVDemo", targets: ["MMKVDemo"]),
    ],
    targets: [
        .binaryTarget(
            name: "MMKV",
            // Change to https://github.com/Tencent/MMKV/releases/download/v1.2.13/MMKV.xcframework.zip once the upstream merges it.
            url: "https://github.com/Kyle-Ye/MMKV/releases/download/v1.2.13/MMKV.xcframework.zip",
            checksum: "7782fbd6896d266d37c97ccb07cf1954de98e6c2a03fc6715cde48fa235151e7"
        )
        .target(
            name: "MMKVDemo",
            dependencies: [
                .product(name: "MMKV", package: "MMKV-XCFramework"),
            ]
        ),
    ]
)
```
2. Add a new repo called MMKV-XCFramework(See https://github.com/Kyle-Ye/MMKV-XCFramework) and wraps the logic in it.

Then for the call site, it just use something like this.

```swift
// MMKVXCFramework
let package = Package(
    name: "MMKVXCFramework",
    products: [.library(name: "MMKV", targets: ["MMKV"])],
    targets: [
        .binaryTarget(
            name: "MMKV",
            url: "https://github.com/Kyle-Ye/MMKV/releases/download/v1.2.13/MMKV.xcframework.zip",
            checksum: "7782fbd6896d266d37c97ccb07cf1954de98e6c2a03fc6715cde48fa235151e7"
        )
    ]
)
```

```swift
// MMKVDemo
let package = Package(
    name: "MMKVDemo",
    products: [
        .library(name: "MMKVDemo", targets: ["MMKVDemo"]),
    ],
    dependencies: [
        .package(url: "https://github.com/Kyle-Ye/MMKV-XCFramework.git", from: "1.2.13"),
    ],
    targets: [
        .target(
            name: "MMKVDemo",
            dependencies: [
                .product(name: "MMKV", package: "MMKV-XCFramework"),
            ]
        ),
    ]
)
```