### PR TITLE
FIX: fix MMKV::getObject crash on iOS

### DIFF
--- a/Core/MMKV_OSX.cpp
+++ b/Core/MMKV_OSX.cpp
@@ -185,7 +185,12 @@ NSObject *MMKV::getObject(MMKVKey_t key, Class cls) {
         } else {
             if ([cls conformsToProtocol:@protocol(NSCoding)]) {
                 auto tmp = [NSData dataWithBytesNoCopy:data.getPtr() length:data.length() freeWhenDone:NO];
-                return [NSKeyedUnarchiver unarchiveObjectWithData:tmp];
+                try {
+                    id result = [NSKeyedUnarchiver unarchiveObjectWithData:tmp];
+                    return result;
+                } catch (NSException *exception) {
+                    MMKVError("%s", exception.reason);
+                }
             }
         }
     }


### PR DESCRIPTION
[NSKeyedUnarchiver unarchiveObjectWithData:] This method raises an NSInvalidArgumentException if data is not a valid archive.
This ouccred tp my app with description: 
MACH_Exception EXC_BAD_ACCESS KERN_INVALID_ADDRESS fault_address:0x0000000000000000