### PR TITLE
fix(cmake): allow to use cmake project on Windows

### DIFF
--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -33,25 +33,28 @@ IF(APPLE)
     add_compile_definitions(FORCE_POSIX)
 ENDIF()
 
-set(can_use_assembler TRUE)
-enable_language(ASM)
-IF("${ANDROID_ABI}" STREQUAL "arm64-v8a")
-    SET(ASM_OPTIONS "-x assembler-with-cpp")
-    SET(CMAKE_ASM_FLAGS "${CFLAGS} ${ASM_OPTIONS} -march=armv8+crypto -D__ANDROID__")
-ELSEIF("${ANDROID_ABI}" STREQUAL "armeabi-v7a")
-    SET(ASM_OPTIONS "-x assembler-with-cpp")
-    SET(CMAKE_ASM_FLAGS "${CFLAGS} ${ASM_OPTIONS} -march=armv7a -D__ANDROID__")
-ELSEIF("${ANDROID_ABI}" STREQUAL "armeabi")
-    SET(ASM_OPTIONS "-x assembler-with-cpp")
-    SET(CMAKE_ASM_FLAGS "${CFLAGS} ${ASM_OPTIONS} -march=armv5 -D__ANDROID__")
-ENDIF()
+set(CAN_USE_ASM-ATT FALSE)
+include(CheckLanguage)
+check_language(ASM-ATT)
+IF(CMAKE_ASM-ATT_COMPILER)
+    enable_language(ASM-ATT)
+    set(CAN_USE_ASM-ATT TRUE)
+    IF("${ANDROID_ABI}" STREQUAL "arm64-v8a")
+        SET(ASM-ATT_OPTIONS "-x assembler-with-cpp")
+        SET(CMAKE_ASM-ATT_FLAGS "${CFLAGS} ${ASM-ATT_OPTIONS} -march=armv8+crypto -D__ANDROID__")
+    ELSEIF("${ANDROID_ABI}" STREQUAL "armeabi-v7a")
+        SET(ASM-ATT_OPTIONS "-x assembler-with-cpp")
+        SET(CMAKE_ASM-ATT_FLAGS "${CFLAGS} ${ASM-ATT_OPTIONS} -march=armv7a -D__ANDROID__")
+    ELSEIF("${ANDROID_ABI}" STREQUAL "armeabi")
+        SET(ASM-ATT_OPTIONS "-x assembler-with-cpp")
+        SET(CMAKE_ASM-ATT_FLAGS "${CFLAGS} ${ASM-ATT_OPTIONS} -march=armv5 -D__ANDROID__")
+    ENDIF()
 
-#include(CMakePrintHelpers)
-#cmake_print_variables(CMAKE_SYSTEM_PROCESSOR)
-IF(UNIX AND (NOT APPLE))
-    IF("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64")
-        SET(ASM_OPTIONS "-x assembler-with-cpp")
-        SET(CMAKE_ASM_FLAGS "${CFLAGS} ${ASM_OPTIONS} -march=armv8-a+crypto")
+    IF(UNIX AND (NOT APPLE))
+        IF("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64")
+            SET(ASM-ATT_OPTIONS "-x assembler-with-cpp")
+            SET(CMAKE_ASM-ATT_FLAGS "${CFLAGS} ${ASM-ATT_OPTIONS} -march=armv8-a+crypto")
+        ENDIF()
     ENDIF()
 ENDIF()
 
@@ -121,8 +124,6 @@ add_library(core
         aes/openssl/openssl_md5_one.cpp
         aes/openssl/openssl_md5.h
         aes/openssl/openssl_md32_common.h
-        aes/openssl/openssl_aesv8-armx.S
-        aes/openssl/openssl_aes-armv4.S
         aes/openssl/openssl_arm_arch.h
         crc32/Checksum.h
         crc32/crc32_armv8.cpp
@@ -133,7 +134,18 @@ add_library(core
         MMKVPredef.h
         )
 
+IF (CAN_USE_ASM-ATT)
+    target_sources(core PRIVATE 
+        aes/openssl/openssl_aesv8-armx.S
+        aes/openssl/openssl_aes-armv4.S)
+ENDIF()
+
 target_include_directories(core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+IF (WIN32)
+    target_compile_definitions(core PUBLIC UNICODE)
+    target_compile_definitions(core PUBLIC _UNICODE)
+ENDIF()
 
 set_target_properties(core PROPERTIES
         CXX_STANDARD 17


### PR DESCRIPTION
#### 1
Win32平台下，目前 MMKV 只在 Unicode 模式下才能编译，因此做出相关 flags 的设置
#### 2
在 Windows 下 `.S` 文件是无法识别的，直接 add source 会报错，这里改为 `check_language` 失败就不添加相应文件的形式
也许再引入一个 `NO_ASM` 宏配合 `check_language` 会更好，不过 MMKV 的设计中似乎并没有类似这样的宏（我也不太会添加）
目前的检测逻辑下，Win32 下始终不会使用 asm （即使是 Win Arm64），因此这样修改已经足够解决问题

