### PR TITLE
fix MMKV getAll()

### DIFF
--- a/Android/MMKV/mmkv/src/main/java/com/tencent/mmkv/MMKV.java
+++ b/Android/MMKV/mmkv/src/main/java/com/tencent/mmkv/MMKV.java
@@ -980,8 +980,14 @@ public class MMKV implements SharedPreferences, SharedPreferences.Editor {
      */
     @Override
     public Map<String, ?> getAll() {
-        throw new java.lang.UnsupportedOperationException(
-            "Intentionally Not Supported. Use allKeys() instead, getAll() not implement because type-erasure inside mmkv");
+        String[] keys = allKeys();
+        Map<String, Object> result = new HashMap<>();
+        if (keys != null) {
+            for (String key : keys) {
+                result.put(key, new Object());
+            }
+        }
+        return result;
     }
 
     @Nullable


### PR DESCRIPTION
In fact, when we use SharedPreference.getAll()，we only want get all keys in SharedPreference. Then we can get value by getString()、getInt() ...

So， MMKV can return all keys with invalid value simply.