### PR TITLE
fix MMKV:lock 线程安全问题

### DIFF
--- a/Core/MMKV.cpp
+++ b/Core/MMKV.cpp
@@ -975,12 +975,15 @@ void MMKV::sync(SyncFlag flag) {
 }
 
 void MMKV::lock() {
+    SCOPED_LOCK(m_lock);
     m_exclusiveProcessLock->lock();
 }
 void MMKV::unlock() {
+    SCOPED_LOCK(m_lock);
     m_exclusiveProcessLock->unlock();
 }
 bool MMKV::try_lock() {
+    SCOPED_LOCK(m_lock);
     return m_exclusiveProcessLock->try_lock();
 }
 


### PR DESCRIPTION
由于暴露了MMKV#lock 方法且未使用线程锁保护，导致在多线程调用 lock 或 unlock 进程锁计数（m_sharedLockCount 和 m_exclusiveLockCount）出错，出现未正常 unlock 的情况或重复flock的情况。从而导致下个进程创建该MMKV时，申请不到flock锁。


