### PR TITLE
fix  Module 'mmkv' not found

### DIFF
--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -23,7 +23,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:mmkv/mmkv.dart';
+import 'package:mmkvflutter/mmkv.dart';
 
 void main() async {
   // must wait for MMKV to finish initialization

--- a/flutter/example/pubspec.yaml
+++ b/flutter/example/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
   path_provider: ">=2.0.1"
 
-  mmkv:
+  mmkvflutter:
     # When depending on this package from a real application you should use:
     #   mmkv: ^x.y.z
     # See https://dart.dev/tools/pub/dependencies#version-constraints

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -1,4 +1,4 @@
-name: mmkv
+name: mmkvflutter
 description: An efficient, small mobile key-value storage framework developed by WeChat. Works on Android, iOS, macOS, Windows, and POSIX.
 version: 1.2.16
 homepage: https://github.com/Tencent/mmkv


### PR DESCRIPTION
<p>when we run the MMKV  example, after uninstall the example app ,and rerun again ,always get error message </p>
<p><pre>Launching lib/main.dart on iPod touch (7th generation) in debug mode...
Running Xcode build...
Xcode build done.                                            5.4s
Failed to build iOS app
Parse Issue (Xcode): Module 'mmkv' not found
/Users//MMKV/flutter/example/ios/Runner/GeneratedPluginRegistrant.m:17:8

Could not build the application for the simulator.
Error launching application on iPod touch (7th generation).</pre></p>

<p><img width="1429" alt="1" src="https://user-images.githubusercontent.com/3911186/227413071-23e0417f-e436-4539-be57-8038252b8ac9.png"></p>
<p><img width="1429" alt="2" src="https://user-images.githubusercontent.com/3911186/227413101-7809302a-4fa0-4cd8-ab8f-edb229103509.png"></p>
<p><img width="1429" alt="3" src="https://user-images.githubusercontent.com/3911186/227413111-61059191-09fc-4be0-a61d-5879e74c810a.png"></p>
<p>the reason is mmkv rename to mmkvflutter only happens when pod install 。 </p>
<p>but ,now  `GeneratedPluginRegistrant.m` always regen when xcode build ,so the modify from `mmkvpodhelper.rb` not work </p>

<p><pre>
flutter doctor
Doctor summary (to see all details, run flutter doctor -v):
[✓] Flutter (Channel stable, 3.7.7, on macOS 11.7.4 20G1120 darwin-x64, locale zh-Hans-CN)
[✓] Android toolchain - develop for Android devices (Android SDK version 33.0.1)
[✓] Xcode - develop for iOS and macOS (Xcode 13.2.1)
[✓] Chrome - develop for the web
[✓] Android Studio (version 2022.1)
[✓] IntelliJ IDEA Ultimate Edition (version 2018.3.6)
[✓] VS Code (version 1.76.2)
[✓] Connected device (3 available)
[✓] HTTP Host Availability

• No issues found!</pre></p>

<p>so ,maybe we need rename mmkv module to mmkvflutter , any better idea ?</p>