### PR TITLE
删除 MMKVContentProvider onCreate 不必要的binder调用

### DIFF
--- a/Android/MMKV/mmkv/src/main/java/com/tencent/mmkv/MMKVContentProvider.java
+++ b/Android/MMKV/mmkv/src/main/java/com/tencent/mmkv/MMKVContentProvider.java
@@ -94,14 +94,6 @@ public class MMKVContentProvider extends ContentProvider {
         if (context == null) {
             return false;
         }
-        String authority = queryAuthority(context);
-        if (authority == null) {
-            return false;
-        }
-
-        if (MMKVContentProvider.gUri == null) {
-            MMKVContentProvider.gUri = Uri.parse(ContentResolver.SCHEME_CONTENT + "://" + authority);
-        }
 
         return true;
     }


### PR DESCRIPTION
MMKVContentProvider.gUri 仅在子进程会被使用到，
onCreate在主进程，减少不必要的 bindler 调用