### PR TITLE
Rookiegan/remove device info plus

### DIFF
--- a/flutter/example/android/app/src/main/AndroidManifest.xml
+++ b/flutter/example/android/app/src/main/AndroidManifest.xml
@@ -25,15 +25,7 @@
               android:name="io.flutter.embedding.android.NormalTheme"
               android:resource="@style/NormalTheme"
               />
-            <!-- Displays an Android View that continues showing the launch screen
-                 Drawable until Flutter paints its first frame, then this splash
-                 screen fades out. A splash screen is useful to avoid any visual
-                 gap between the end of Android's launch screen and the painting of
-                 Flutter's first frame. -->
-            <meta-data
-              android:name="io.flutter.embedding.android.SplashScreenDrawable"
-              android:resource="@drawable/launch_background"
-              />
+
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/flutter/example/android/app/src/main/AndroidManifest.xml
+++ b/flutter/example/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
          In most cases you can leave this as-is, but you if you want to provide
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
+    <uses-permission android:name="android.permission.INTERNET"/>
+
     <application
         android:name="${applicationName}"
         android:label="mmkv_example"

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
     sdk: flutter
   path_provider: ^2.0.1
   ffi: ^2.0.0
-  device_info_plus: ^4.0.0
 
 dev_dependencies:
   test:


### PR DESCRIPTION
Fixed three issues:
1. device_info_plus 4.0.0 has been added to the mmkv flutter library,but It is too old, the latest version of device_info_plus is 8.2.0, easy to conflict with other libraries. Look at the mmkv code and see that it is not being used, so remove it.

2. Fixed flutter example startup error 1, refer to [Deprecated Splash Screen API Migration](https://docs.flutter.dev/development/platform-integration/android/splash-screen-migration)
![image](https://user-images.githubusercontent.com/29536791/232996911-ee34b3e7-1fde-4773-b9d3-2e7c604b9abb.png)

3. Fixed flutter example startup error 2
![image](https://user-images.githubusercontent.com/29536791/233000309-3de32ba6-7d38-4c3c-9f9f-472a32ecab1b.png)


