### PR TITLE
set expected capacity for file length when init #1114

### DIFF
--- a/Android/MMKV/mmkv/src/main/cpp/native-bridge.cpp
+++ b/Android/MMKV/mmkv/src/main/cpp/native-bridge.cpp
@@ -294,7 +294,8 @@ static void onContentChangedByOuterProcess(const std::string &mmapID) {
     }
 }
 
-MMKV_JNI jlong getMMKVWithID(JNIEnv *env, jobject, jstring mmapID, jint mode, jstring cryptKey, jstring rootPath) {
+MMKV_JNI jlong getMMKVWithID(JNIEnv *env, jobject, jstring mmapID, jint mode, jstring cryptKey, jstring rootPath,
+                             jlong expectedCapacity) {
     MMKV *kv = nullptr;
     if (!mmapID) {
         return (jlong) kv;
@@ -307,9 +308,9 @@ MMKV_JNI jlong getMMKVWithID(JNIEnv *env, jobject, jstring mmapID, jint mode, js
         if (crypt.length() > 0) {
             if (rootPath) {
                 string path = jstring2string(env, rootPath);
-                kv = MMKV::mmkvWithID(str, DEFAULT_MMAP_SIZE, (MMKVMode) mode, &crypt, &path);
+                kv = MMKV::mmkvWithID(str, DEFAULT_MMAP_SIZE, (MMKVMode) mode, &crypt, &path, expectedCapacity);
             } else {
-                kv = MMKV::mmkvWithID(str, DEFAULT_MMAP_SIZE, (MMKVMode) mode, &crypt, nullptr);
+                kv = MMKV::mmkvWithID(str, DEFAULT_MMAP_SIZE, (MMKVMode) mode, &crypt, nullptr, expectedCapacity);
             }
             done = true;
         }
@@ -317,9 +318,9 @@ MMKV_JNI jlong getMMKVWithID(JNIEnv *env, jobject, jstring mmapID, jint mode, js
     if (!done) {
         if (rootPath) {
             string path = jstring2string(env, rootPath);
-            kv = MMKV::mmkvWithID(str, DEFAULT_MMAP_SIZE, (MMKVMode) mode, nullptr, &path);
+            kv = MMKV::mmkvWithID(str, DEFAULT_MMAP_SIZE, (MMKVMode) mode, nullptr, &path, expectedCapacity);
         } else {
-            kv = MMKV::mmkvWithID(str, DEFAULT_MMAP_SIZE, (MMKVMode) mode, nullptr, nullptr);
+            kv = MMKV::mmkvWithID(str, DEFAULT_MMAP_SIZE, (MMKVMode) mode, nullptr, nullptr, expectedCapacity);
         }
     }
 
@@ -1040,7 +1041,7 @@ static JNINativeMethod g_methods[] = {
     {"ashmemMetaFD", "()I", (void *) mmkv::ashmemMetaFD},
     //{"jniInitialize", "(Ljava/lang/String;Ljava/lang/String;I)V", (void *) mmkv::jniInitialize},
     {"jniInitialize", "(Ljava/lang/String;Ljava/lang/String;IZ)V", (void *) mmkv::jniInitialize_2},
-    {"getMMKVWithID", "(Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;)J", (void *) mmkv::getMMKVWithID},
+    {"getMMKVWithID", "(Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;J)J", (void *) mmkv::getMMKVWithID},
     {"getMMKVWithIDAndSize", "(Ljava/lang/String;IILjava/lang/String;)J", (void *) mmkv::getMMKVWithIDAndSize},
     {"getDefaultMMKV", "(ILjava/lang/String;)J", (void *) mmkv::getDefaultMMKV},
     {"getMMKVWithAshmemFD", "(Ljava/lang/String;IILjava/lang/String;)J", (void *) mmkv::getMMKVWithAshmemFD},

--- a/Android/MMKV/mmkv/src/main/java/com/tencent/mmkv/MMKV.java
+++ b/Android/MMKV/mmkv/src/main/java/com/tencent/mmkv/MMKV.java
@@ -340,7 +340,7 @@ public class MMKV implements SharedPreferences, SharedPreferences.Editor {
             throw new IllegalStateException("You should Call MMKV.initialize() first.");
         }
 
-        long handle = getMMKVWithID(mmapID, SINGLE_PROCESS_MODE, null, null);
+        long handle = getMMKVWithID(mmapID, SINGLE_PROCESS_MODE, null, null, 0);
         return checkProcessMode(handle, mmapID, SINGLE_PROCESS_MODE);
     }
 
@@ -356,7 +356,24 @@ public class MMKV implements SharedPreferences, SharedPreferences.Editor {
             throw new IllegalStateException("You should Call MMKV.initialize() first.");
         }
 
-        long handle = getMMKVWithID(mmapID, mode, null, null);
+        long handle = getMMKVWithID(mmapID, mode, null, null, 0);
+        return checkProcessMode(handle, mmapID, mode);
+    }
+
+    /**
+     * Create an MMKV instance in single-process or multi-process mode.
+     *
+     * @param mmapID The unique ID of the MMKV instance.
+     * @param mode   The process mode of the MMKV instance, defaults to {@link #SINGLE_PROCESS_MODE}.
+     * @param expectedCapacity The file size you expected when opening or creating file
+     * @throws RuntimeException if there's an runtime error.
+     */
+    public static MMKV mmkvWithID(String mmapID, int mode, long expectedCapacity) throws RuntimeException {
+        if (rootDir == null) {
+            throw new IllegalStateException("You should Call MMKV.initialize() first.");
+        }
+
+        long handle = getMMKVWithID(mmapID, mode, null, null, expectedCapacity);
         return checkProcessMode(handle, mmapID, mode);
     }
 
@@ -373,7 +390,7 @@ public class MMKV implements SharedPreferences, SharedPreferences.Editor {
             throw new IllegalStateException("You should Call MMKV.initialize() first.");
         }
 
-        long handle = getMMKVWithID(mmapID, mode, cryptKey, null);
+        long handle = getMMKVWithID(mmapID, mode, cryptKey, null, 0);
         return checkProcessMode(handle, mmapID, mode);
     }
 
@@ -389,8 +406,45 @@ public class MMKV implements SharedPreferences, SharedPreferences.Editor {
             throw new IllegalStateException("You should Call MMKV.initialize() first.");
         }
 
-        long handle = getMMKVWithID(mmapID, SINGLE_PROCESS_MODE, null, rootPath);
+        long handle = getMMKVWithID(mmapID, SINGLE_PROCESS_MODE, null, rootPath, 0);
         return checkProcessMode(handle, mmapID, SINGLE_PROCESS_MODE);
+    }
+
+    /**
+     * Create an MMKV instance in customize folder.
+     *
+     * @param mmapID   The unique ID of the MMKV instance.
+     * @param rootPath The folder of the MMKV instance, defaults to $(FilesDir)/mmkv.
+     * @param expectedCapacity The file size you expected when opening or creating file
+     * @throws RuntimeException if there's an runtime error.
+     */
+    public static MMKV mmkvWithID(String mmapID, String rootPath, long expectedCapacity) throws RuntimeException {
+        if (rootDir == null) {
+            throw new IllegalStateException("You should Call MMKV.initialize() first.");
+        }
+
+        long handle = getMMKVWithID(mmapID, SINGLE_PROCESS_MODE, null, rootPath, expectedCapacity);
+        return checkProcessMode(handle, mmapID, SINGLE_PROCESS_MODE);
+    }
+
+    /**
+     * Create an MMKV instance with customize settings all in one.
+     *
+     * @param mmapID   The unique ID of the MMKV instance.
+     * @param mode     The process mode of the MMKV instance, defaults to {@link #SINGLE_PROCESS_MODE}.
+     * @param cryptKey The encryption key of the MMKV instance (no more than 16 bytes).
+     * @param rootPath The folder of the MMKV instance, defaults to $(FilesDir)/mmkv.
+     * @param expectedCapacity The file size you expected when opening or creating file
+     * @throws RuntimeException if there's an runtime error.
+     */
+    public static MMKV mmkvWithID(String mmapID, int mode, @Nullable String cryptKey, String rootPath, long expectedCapacity)
+            throws RuntimeException {
+        if (rootDir == null) {
+            throw new IllegalStateException("You should Call MMKV.initialize() first.");
+        }
+
+        long handle = getMMKVWithID(mmapID, mode, cryptKey, rootPath, expectedCapacity);
+        return checkProcessMode(handle, mmapID, mode);
     }
 
     /**
@@ -408,7 +462,7 @@ public class MMKV implements SharedPreferences, SharedPreferences.Editor {
             throw new IllegalStateException("You should Call MMKV.initialize() first.");
         }
 
-        long handle = getMMKVWithID(mmapID, mode, cryptKey, rootPath);
+        long handle = getMMKVWithID(mmapID, mode, cryptKey, rootPath, 0);
         return checkProcessMode(handle, mmapID, mode);
     }
 
@@ -428,7 +482,7 @@ public class MMKV implements SharedPreferences, SharedPreferences.Editor {
         }
 
         mode |= BACKUP_MODE;
-        long handle = getMMKVWithID(mmapID, mode, cryptKey, rootPath);
+        long handle = getMMKVWithID(mmapID, mode, cryptKey, rootPath, 0);
         return checkProcessMode(handle, mmapID, mode);
     }
 
@@ -1522,7 +1576,8 @@ public class MMKV implements SharedPreferences, SharedPreferences.Editor {
     private static native void jniInitialize(String rootDir, String cacheDir, int level, boolean wantLogReDirecting);
 
     private native static long
-    getMMKVWithID(String mmapID, int mode, @Nullable String cryptKey, @Nullable String rootPath);
+    getMMKVWithID(String mmapID, int mode, @Nullable String cryptKey, @Nullable String rootPath,
+                  long expectedCapacity);
 
     private native static long getMMKVWithIDAndSize(String mmapID, int size, int mode, @Nullable String cryptKey);
 

--- a/Android/MMKV/mmkvdemo/src/main/java/com/tencent/mmkvdemo/MainActivity.java
+++ b/Android/MMKV/mmkvdemo/src/main/java/com/tencent/mmkvdemo/MainActivity.java
@@ -123,6 +123,7 @@ public class MainActivity extends AppCompatActivity {
         testRestore();
 
         testAutoExpire();
+        testExpectedCapacity();
     }
 
     private void testInterProcessLogic() {
@@ -656,5 +657,14 @@ public class MainActivity extends AppCompatActivity {
         } else {
             Log.e("MMKV", "auto key expiration never_expire_key_1");
         }
+    }
+
+    private void testExpectedCapacity() {
+        MMKV mmkv = MMKV.mmkvWithID("test_expected_capacity", MMKV.SINGLE_PROCESS_MODE, 4097);
+        mmkv.encode("test_expected_capacity_1", true);
+        Log.i("MMKV", "test_expected_capacity count = " + mmkv.count() + ", totalSize = " + mmkv.totalSize()
+                        + ", actualSize = " + mmkv.actualSize());
+
+
     }
 }

--- a/Core/MMKV.cpp
+++ b/Core/MMKV.cpp
@@ -77,13 +77,14 @@ bool endsWith(const MMKVPath_t &str, const MMKVPath_t &suffix);
 MMKVPath_t filename(const MMKVPath_t &path);
 
 #ifndef MMKV_ANDROID
-MMKV::MMKV(const string &mmapID, MMKVMode mode, string *cryptKey, MMKVPath_t *rootPath)
+MMKV::MMKV(const string &mmapID, MMKVMode mode, string *cryptKey, MMKVPath_t *rootPath,
+           size_t expectedCapacity)
     : m_mmapID(mmapID)
     , m_path(mappedKVPathWithID(m_mmapID, mode, rootPath))
     , m_crcPath(crcPathWithID(m_mmapID, mode, rootPath))
     , m_dic(nullptr)
     , m_dicCrypt(nullptr)
-    , m_file(new MemoryFile(m_path))
+    , m_file(new MemoryFile(m_path, expectedCapacity))
     , m_metaFile(new MemoryFile(m_crcPath))
     , m_metaInfo(new MMKVMetaInfo())
     , m_crypter(nullptr)
@@ -212,7 +213,7 @@ const MMKVPath_t &MMKV::getRootDir() {
 }
 
 #ifndef MMKV_ANDROID
-MMKV *MMKV::mmkvWithID(const string &mmapID, MMKVMode mode, string *cryptKey, MMKVPath_t *rootPath) {
+MMKV *MMKV::mmkvWithID(const string &mmapID, MMKVMode mode, string *cryptKey, MMKVPath_t *rootPath, size_t expectedCapacity) {
 
     if (mmapID.empty()) {
         return nullptr;
@@ -234,7 +235,7 @@ MMKV *MMKV::mmkvWithID(const string &mmapID, MMKVMode mode, string *cryptKey, MM
         MMKVInfo("prepare to load %s (id %s) from rootPath %s", mmapID.c_str(), mmapKey.c_str(), rootPath->c_str());
     }
 
-    auto kv = new MMKV(mmapID, mode, cryptKey, rootPath);
+    auto kv = new MMKV(mmapID, mode, cryptKey, rootPath, expectedCapacity);
     kv->m_mmapKey = mmapKey;
     (*g_instanceDic)[mmapKey] = kv;
     return kv;

--- a/Core/MMKV.h
+++ b/Core/MMKV.h
@@ -52,13 +52,15 @@ enum MMKVMode : uint32_t {
 class MMKV {
 #ifndef MMKV_ANDROID
     std::string m_mmapKey;
-    MMKV(const std::string &mmapID, MMKVMode mode, std::string *cryptKey, MMKVPath_t *rootPath);
+    MMKV(const std::string &mmapID, MMKVMode mode, std::string *cryptKey, MMKVPath_t *rootPath,
+         size_t expectedCapacity = 0);
 #else // defined(MMKV_ANDROID)
     mmkv::FileLock *m_fileModeLock;
     mmkv::InterProcessLock *m_sharedProcessModeLock;
     mmkv::InterProcessLock *m_exclusiveProcessModeLock;
 
-    MMKV(const std::string &mmapID, int size, MMKVMode mode, std::string *cryptKey, MMKVPath_t *rootPath);
+    MMKV(const std::string &mmapID, int size, MMKVMode mode, std::string *cryptKey, MMKVPath_t *rootPath,
+         size_t expectedCapacity = 0);
 
     MMKV(const std::string &mmapID, int ashmemFD, int ashmemMetaFd, std::string *cryptKey = nullptr);
 #endif
@@ -196,7 +198,8 @@ public:
     static MMKV *mmkvWithID(const std::string &mmapID,
                             MMKVMode mode = MMKV_SINGLE_PROCESS,
                             std::string *cryptKey = nullptr,
-                            MMKVPath_t *rootPath = nullptr);
+                            MMKVPath_t *rootPath = nullptr,
+                            size_t expectedCapacity = 0);
 
 #else // defined(MMKV_ANDROID)
 
@@ -207,7 +210,8 @@ public:
                             int size = mmkv::DEFAULT_MMAP_SIZE,
                             MMKVMode mode = MMKV_SINGLE_PROCESS,
                             std::string *cryptKey = nullptr,
-                            MMKVPath_t *rootPath = nullptr);
+                            MMKVPath_t *rootPath = nullptr,
+                            size_t expectedCapacity = 0);
 
     static MMKV *mmkvWithAshmemFD(const std::string &mmapID, int fd, int metaFD, std::string *cryptKey = nullptr);
 

--- a/Core/MemoryFile.cpp
+++ b/Core/MemoryFile.cpp
@@ -49,8 +49,8 @@ File::File(MMKVPath_t path, OpenFlag flag) : m_path(std::move(path)), m_fd(-1), 
     open();
 }
 
-MemoryFile::MemoryFile(MMKVPath_t path) : m_diskFile(std::move(path), OpenFlag::ReadWrite | OpenFlag::Create), m_ptr(nullptr), m_size(0) {
-    reloadFromFile();
+MemoryFile::MemoryFile(MMKVPath_t path, size_t expectedCapacity) : m_diskFile(std::move(path), OpenFlag::ReadWrite | OpenFlag::Create), m_ptr(nullptr), m_size(0) {
+    reloadFromFile(expectedCapacity);
 }
 #    endif // !defined(MMKV_ANDROID)
 
@@ -192,7 +192,7 @@ bool MemoryFile::mmap() {
     return true;
 }
 
-void MemoryFile::reloadFromFile() {
+void MemoryFile::reloadFromFile(size_t expectedCapacity) {
 #    ifdef MMKV_ANDROID
     if (m_fileType == MMFILE_TYPE_ASHMEM) {
         return;
@@ -212,9 +212,13 @@ void MemoryFile::reloadFromFile() {
         SCOPED_LOCK(&lock);
 
         mmkv::getFileSize(m_diskFile.m_fd, m_size);
+        size_t expectedSize = std::max<size_t>(DEFAULT_MMAP_SIZE, expectedCapacity);
         // round up to (n * pagesize)
-        if (m_size < DEFAULT_MMAP_SIZE || (m_size % DEFAULT_MMAP_SIZE != 0)) {
-            size_t roundSize = ((m_size / DEFAULT_MMAP_SIZE) + 1) * DEFAULT_MMAP_SIZE;
+        expectedSize = (expectedSize + DEFAULT_MMAP_SIZE - 1) / DEFAULT_MMAP_SIZE * DEFAULT_MMAP_SIZE;
+        
+        if (m_size < expectedSize || (m_size % DEFAULT_MMAP_SIZE != 0)) {
+            size_t roundSize = ((m_size / DEFAULT_MMAP_SIZE) + 1) * DEFAULT_MMAP_SIZE;;
+            roundSize = std::max<size_t>(expectedSize, roundSize);
             truncate(roundSize);
         } else {
             auto ret = mmap();

--- a/Core/MemoryFile.h
+++ b/Core/MemoryFile.h
@@ -110,9 +110,9 @@ class MemoryFile {
 
 public:
 #ifndef MMKV_ANDROID
-    explicit MemoryFile(MMKVPath_t path);
+    explicit MemoryFile(MMKVPath_t path, size_t expectedCapacity = 0);
 #else
-    MemoryFile(MMKVPath_t path, size_t size, FileType fileType);
+    MemoryFile(MMKVPath_t path, size_t size, FileType fileType, size_t expectedCapacity = 0);
     explicit MemoryFile(MMKVFileHandle_t ashmemFD);
 
     const FileType m_fileType;
@@ -137,7 +137,7 @@ public:
     bool msync(SyncFlag syncFlag);
 
     // call this if clearMemoryCache() has been called
-    void reloadFromFile();
+    void reloadFromFile(size_t expectedCapacity = 0);
 
     void clearMemoryCache() { doCleanMemoryCache(false); }
 

--- a/Core/MemoryFile_Android.cpp
+++ b/Core/MemoryFile_Android.cpp
@@ -70,10 +70,10 @@ File::File(MMKVFileHandle_t ashmemFD)
     }
 }
 
-MemoryFile::MemoryFile(string path, size_t size, FileType fileType)
+MemoryFile::MemoryFile(string path, size_t size, FileType fileType, size_t expectedCapacity)
     : m_diskFile(std::move(path), OpenFlag::ReadWrite | OpenFlag::Create, size, fileType), m_ptr(nullptr), m_size(0), m_fileType(fileType) {
     if (m_fileType == MMFILE_TYPE_FILE) {
-        reloadFromFile();
+        reloadFromFile(expectedCapacity);
     } else {
         if (m_diskFile.isFileValid()) {
             m_size = m_diskFile.m_size;

--- a/POSIX/Python/demo.py
+++ b/POSIX/Python/demo.py
@@ -70,6 +70,14 @@ def test_backup():
     print("backup all count: ", count)
 
 
+def test_expectedCapacity():
+    mmap_id = "mmkv_capacity"
+
+    kv = mmkv.MMKV(mmap_id, mmkv.MMKVMode.SingleProcess, "", "", 4097)
+    kv.set("data with capacity", "key")
+    print("test_expectedCapacity,  ", kv.getString("key"))
+
+
 def test_restore():
     root_dir = "/tmp/mmkv_backup"
     mmap_id = "test/Encrypt"
@@ -147,6 +155,7 @@ if __name__ == '__main__':
     # get notified after content changed by other process
     # mmkv.MMKV.registerContentChangeHandler(content_change_handler)
 
+    test_expectedCapacity()
     functional_test('test_python', False)
 
     test_backup()

--- a/POSIX/Python/libmmkv_python.cpp
+++ b/POSIX/Python/libmmkv_python.cpp
@@ -99,18 +99,19 @@ PYBIND11_MODULE(mmkv, m) {
     //             py::arg("cryptKey") = (string*) nullptr,
     //             py::arg("rootDir") = (string*) nullptr);
 
-    clsMMKV.def(py::init([](const string &mmapID, MMKVMode mode, const string &cryptKey, const string &rootDir) {
+    clsMMKV.def(py::init([](const string &mmapID, MMKVMode mode, const string &cryptKey, const string &rootDir, const size_t expectedCapacity) {
                     string *cryptKeyPtr = (cryptKey.length() > 0) ? (string *) &cryptKey : nullptr;
                     string *rootDirPtr = (rootDir.length() > 0) ? (string *) &rootDir : nullptr;
-                    return MMKV::mmkvWithID(mmapID, mode, cryptKeyPtr, rootDirPtr);
+                    return MMKV::mmkvWithID(mmapID, mode, cryptKeyPtr, rootDirPtr, expectedCapacity);
                 }),
                 "Parameters:\n"
                 "  mmapID: all instances of the same mmapID share the same data and file storage\n"
                 "  mode: pass MMKVMode.MultiProcess for a multi-process MMKV\n"
                 "  cryptKey: pass a non-empty string for an encrypted MMKV, 16 bytes at most\n"
                 "  rootDir: custom root directory",
+                "  expectedCapacity: the file size you expected when opening or creating file",
                 py::arg("mmapID"), py::arg("mode") = MMKV_SINGLE_PROCESS, py::arg("cryptKey") = string(),
-                py::arg("rootDir") = string());
+                py::arg("rootDir") = string(), py::arg("expectedCapacity") = 0);
 
     clsMMKV.def("__eq__", [](MMKV &kv, const MMKV &other) { return kv.mmapID() == other.mmapID(); });
 

--- a/POSIX/demo/demo.cpp
+++ b/POSIX/demo/demo.cpp
@@ -365,6 +365,30 @@ void testAutoExpiration() {
     assert(mmkv->containsKey("auto_expire_key_1") == false);
 }
 
+void testExpectedCapacity() {
+    auto mmkv0 = MMKV::mmkvWithID("testExpectedCapacity0", MMKV_SINGLE_PROCESS, nullptr, nullptr, DEFAULT_MMAP_SIZE);
+    assert(mmkv0->totalSize() == DEFAULT_MMAP_SIZE);
+
+    auto mmkv1 = MMKV::mmkvWithID("testExpectedCapacity1", MMKV_SINGLE_PROCESS, nullptr, nullptr, DEFAULT_MMAP_SIZE + 1);
+    assert(mmkv1->totalSize() == DEFAULT_MMAP_SIZE << 1);
+
+    auto mmkv2 = MMKV::mmkvWithID("testExpectedCapacity2", MMKV_SINGLE_PROCESS, nullptr, nullptr, DEFAULT_MMAP_SIZE - 1);
+    assert(mmkv2->totalSize() == DEFAULT_MMAP_SIZE);
+
+    auto mmkv3 = MMKV::mmkvWithID("testExpectedCapacity3");
+    mmkv3->clearAll();
+    assert(mmkv3->totalSize() == DEFAULT_MMAP_SIZE);
+    mmkv3->close();
+    // expand it
+    mmkv3 = MMKV::mmkvWithID("testExpectedCapacity3", MMKV_SINGLE_PROCESS, nullptr, nullptr, 100 * DEFAULT_MMAP_SIZE + 100);
+    assert(mmkv3->totalSize() == DEFAULT_MMAP_SIZE * 101);
+
+    // if new size is smaller than file size, keep file its origin size
+    mmkv3->close();
+    mmkv3 = MMKV::mmkvWithID("testExpectedCapacity3", MMKV_SINGLE_PROCESS, nullptr, nullptr, 0);
+    assert(mmkv3->totalSize() == DEFAULT_MMAP_SIZE * 101);
+}
+
 void MyLogHandler(MMKVLogLevel level, const char *file, int line, const char *function, const string &message) {
 
     auto desc = [level] {
@@ -415,4 +439,5 @@ int main() {
     testBackup();
     testRestore();
     testAutoExpiration();
+    testExpectedCapacity();
 }

--- a/POSIX/golang/golang-bridge.cpp
+++ b/POSIX/golang/golang-bridge.cpp
@@ -47,7 +47,8 @@ MMKV_EXPORT void onExit() {
     MMKV::onExit();
 }
 
-MMKV_EXPORT void *getMMKVWithID(GoStringWrap mmapID, int32_t mode, GoStringWrap cryptKey, GoStringWrap rootPath) {
+MMKV_EXPORT void *getMMKVWithID(GoStringWrap mmapID, int32_t mode, GoStringWrap cryptKey, 
+                                GoStringWrap rootPath, uint64_t expectedCapacity) {
     MMKV *kv = nullptr;
     if (!mmapID.ptr) {
         return kv;
@@ -60,9 +61,9 @@ MMKV_EXPORT void *getMMKVWithID(GoStringWrap mmapID, int32_t mode, GoStringWrap 
         if (crypt.length() > 0) {
             if (rootPath.ptr) {
                 auto path = string(rootPath.ptr, rootPath.length);
-                kv = MMKV::mmkvWithID(str, (MMKVMode) mode, &crypt, &path);
+                kv = MMKV::mmkvWithID(str, (MMKVMode) mode, &crypt, &path, expectedCapacity);
             } else {
-                kv = MMKV::mmkvWithID(str, (MMKVMode) mode, &crypt, nullptr);
+                kv = MMKV::mmkvWithID(str, (MMKVMode) mode, &crypt, nullptr, expectedCapacity);
             }
             done = true;
         }
@@ -70,9 +71,9 @@ MMKV_EXPORT void *getMMKVWithID(GoStringWrap mmapID, int32_t mode, GoStringWrap 
     if (!done) {
         if (rootPath.ptr) {
             auto path = string(rootPath.ptr, rootPath.length);
-            kv = MMKV::mmkvWithID(str, (MMKVMode) mode, nullptr, &path);
+            kv = MMKV::mmkvWithID(str, (MMKVMode) mode, nullptr, &path, expectedCapacity);
         } else {
-            kv = MMKV::mmkvWithID(str, (MMKVMode) mode, nullptr, nullptr);
+            kv = MMKV::mmkvWithID(str, (MMKVMode) mode, nullptr, nullptr, expectedCapacity);
         }
     }
 

--- a/POSIX/golang/golang-bridge.h
+++ b/POSIX/golang/golang-bridge.h
@@ -42,7 +42,8 @@ typedef struct GoSliceWrap GoSliceWrap_t;
 void mmkvInitialize(GoStringWrap_t rootDir, int32_t logLevel, bool redirect);
 void onExit();
 
-void *getMMKVWithID(GoStringWrap_t mmapID, int32_t mode, GoStringWrap_t cryptKey, GoStringWrap_t rootPath);
+void *getMMKVWithID(GoStringWrap_t mmapID, int32_t mode, GoStringWrap_t cryptKey, 
+                    GoStringWrap_t rootPath, uint64_t expectedCapacity);
 void *getDefaultMMKV(int32_t mode, GoStringWrap_t cryptKey);
 const char *mmapID(void *handle);
 

--- a/POSIX/golang/mmkv.go
+++ b/POSIX/golang/mmkv.go
@@ -285,21 +285,29 @@ func DefaultMMKVWithModeAndCryptKey(mode int, cryptKey string) MMKV {
 // an instance with specific location ${MMKV Root}/mmapID, in single-process mode.
 func MMKVWithID(mmapID string) MMKV {
 	cStrNull := C.GoStringWrapNil()
-	mmkv := ctorMMKV(C.getMMKVWithID(C.wrapGoString(mmapID), MMKV_SINGLE_PROCESS, cStrNull, cStrNull))
+	mmkv := ctorMMKV(C.getMMKVWithID(C.wrapGoString(mmapID), MMKV_SINGLE_PROCESS, cStrNull, cStrNull, 0))
 	return MMKV(mmkv)
+}
+
+// an instance with specific location ${MMKV Root}/mmapID, in single-process mode.
+func MMKVWithIDAndExpectedCapacity(mmapID string, expectedCapacity uint64) MMKV {
+        cStrNull := C.GoStringWrapNil()
+        mmkv := ctorMMKV(C.getMMKVWithID(C.wrapGoString(mmapID), MMKV_SINGLE_PROCESS, cStrNull, cStrNull, 
+                         C.uint64_t(expectedCapacity)))
+        return MMKV(mmkv)
 }
 
 // an instance with specific location ${MMKV Root}/mmapID, in single-process or multi-process mode.
 func MMKVWithIDAndMode(mmapID string, mode int) MMKV {
 	cStrNull := C.GoStringWrapNil()
-	mmkv := ctorMMKV(C.getMMKVWithID(C.wrapGoString(mmapID), C.int(mode), cStrNull, cStrNull))
+	mmkv := ctorMMKV(C.getMMKVWithID(C.wrapGoString(mmapID), C.int(mode), cStrNull, cStrNull, 0))
 	return MMKV(mmkv)
 }
 
 // an encrypted instance with specific location ${MMKV Root}/mmapID, in single-process or multi-process mode.
 func MMKVWithIDAndModeAndCryptKey(mmapID string, mode int, cryptKey string) MMKV {
 	cStrNull := C.GoStringWrapNil()
-	mmkv := ctorMMKV(C.getMMKVWithID(C.wrapGoString(mmapID), C.int(mode), C.wrapGoString(cryptKey), cStrNull))
+	mmkv := ctorMMKV(C.getMMKVWithID(C.wrapGoString(mmapID), C.int(mode), C.wrapGoString(cryptKey), cStrNull, 0))
 	return MMKV(mmkv)
 }
 

--- a/POSIX/golang/test/main.go
+++ b/POSIX/golang/test/main.go
@@ -20,7 +20,8 @@ func main() {
 	mmkv.RegisterErrorHandler(errorHandler)
 	// you can get notify content change by other process (not in realtime)
 	mmkv.RegisterContentChangeHandler(contentChangeNotify)
-
+       
+	testExpectedCapacity()
 	functionalTest()
 	testReKey()
 
@@ -176,6 +177,12 @@ func testBackup() {
 
 	count := mmkv.BackupAllToDirectory(rootDir)
 	fmt.Println("backup all count: ", count)
+}
+
+func testExpectedCapacity() {
+       kv := mmkv.MMKVWithIDAndExpectedCapacity("capacity", 4196) 
+       kv.SetString("data with capacity", "key")
+      fmt.Println("string =", kv.GetString("key"))       
 }
 
 func testRestore() {

--- a/iOS/MMKV/MMKV/MMKV.h
+++ b/iOS/MMKV/MMKV/MMKV.h
@@ -81,12 +81,21 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable instancetype)mmkvWithID:(NSString *)mmapID NS_SWIFT_NAME(init(mmapID:));
 
 /// @param mmapID any unique ID (com.tencent.xin.pay, etc), if you want a per-user mmkv, you could merge user-id within mmapID
+/// @param expectedCapacity the file size you expected when opening or creating file
++ (nullable instancetype)mmkvWithID:(NSString *)mmapID expectedCapacity:(size_t)expectedCapacity NS_SWIFT_NAME(init(mmapID:expectedCapacity:));
+
+/// @param mmapID any unique ID (com.tencent.xin.pay, etc), if you want a per-user mmkv, you could merge user-id within mmapID
 /// @param mode MMKVMultiProcess for multi-process MMKV
 + (nullable instancetype)mmkvWithID:(NSString *)mmapID mode:(MMKVMode)mode NS_SWIFT_NAME(init(mmapID:mode:));
 
 /// @param mmapID any unique ID (com.tencent.xin.pay, etc), if you want a per-user mmkv, you could merge user-id within mmapID
 /// @param cryptKey 16 bytes at most
 + (nullable instancetype)mmkvWithID:(NSString *)mmapID cryptKey:(nullable NSData *)cryptKey NS_SWIFT_NAME(init(mmapID:cryptKey:));
+
+/// @param mmapID any unique ID (com.tencent.xin.pay, etc), if you want a per-user mmkv, you could merge user-id within mmapID
+/// @param cryptKey 16 bytes at most
+/// @param expectedCapacity the file size you expected when opening or creating file
++ (nullable instancetype)mmkvWithID:(NSString *)mmapID cryptKey:(nullable NSData *)cryptKey expectedCapacity:(size_t)expectedCapacity NS_SWIFT_NAME(init(mmapID:cryptKey:expectedCapacity:));
 
 /// @param mmapID any unique ID (com.tencent.xin.pay, etc), if you want a per-user mmkv, you could merge user-id within mmapID
 /// @param cryptKey 16 bytes at most
@@ -102,6 +111,11 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable instancetype)mmkvWithID:(NSString *)mmapID rootPath:(nullable NSString *)rootPath NS_SWIFT_NAME(init(mmapID:rootPath:));
 
 /// @param mmapID any unique ID (com.tencent.xin.pay, etc), if you want a per-user mmkv, you could merge user-id within mmapID
+/// @param rootPath custom path of the file, `NSDocumentDirectory/mmkv` by default
+/// @param expectedCapacity the file size you expected when opening or creating file
++ (nullable instancetype)mmkvWithID:(NSString *)mmapID rootPath:(nullable NSString *)rootPath expectedCapacity:(size_t)expectedCapacity NS_SWIFT_NAME(init(mmapID:rootPath:expectedCapacity:));
+
+/// @param mmapID any unique ID (com.tencent.xin.pay, etc), if you want a per-user mmkv, you could merge user-id within mmapID
 /// @param cryptKey 16 bytes at most
 /// @param relativePath custom path of the file, `NSDocumentDirectory/mmkv` by default
 + (nullable instancetype)mmkvWithID:(NSString *)mmapID cryptKey:(nullable NSData *)cryptKey relativePath:(nullable NSString *)relativePath NS_SWIFT_NAME(init(mmapID:cryptKey:relativePath:)) __attribute__((deprecated("use +mmkvWithID:cryptKey:rootPath: instead")));
@@ -110,6 +124,13 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param cryptKey 16 bytes at most
 /// @param rootPath custom path of the file, `NSDocumentDirectory/mmkv` by default
 + (nullable instancetype)mmkvWithID:(NSString *)mmapID cryptKey:(nullable NSData *)cryptKey rootPath:(nullable NSString *)rootPath NS_SWIFT_NAME(init(mmapID:cryptKey:rootPath:));
+
+/// @param mmapID any unique ID (com.tencent.xin.pay, etc), if you want a per-user mmkv, you could merge user-id within mmapID
+/// @param cryptKey 16 bytes at most
+/// @param rootPath custom path of the file, `NSDocumentDirectory/mmkv` by default
+/// @param expectedCapacity the file size you expected when opening or creating file
++ (nullable instancetype)mmkvWithID:(NSString *)mmapID cryptKey:(nullable NSData *)cryptKey rootPath:(nullable NSString *)rootPath expectedCapacity:(size_t)expectedCapacity NS_SWIFT_NAME(init(mmapID:cryptKey:rootPath:expectedCapacity:));
+
 
 /// you can call this on applicationWillTerminate, it's totally fine if you don't call
 + (void)onAppTerminate;

--- a/iOS/MMKV/MMKV/libMMKV.mm
+++ b/iOS/MMKV/MMKV/libMMKV.mm
@@ -155,6 +155,11 @@ static BOOL g_hasCalledInitializeMMKV = NO;
     return [MMKV mmkvWithID:mmapID cryptKey:nil rootPath:nil mode:MMKVSingleProcess];
 }
 
++ (instancetype)mmkvWithID:(NSString *)mmapID expectedCapacity:(size_t)expectedCapacity {
+    return [MMKV mmkvWithID:mmapID cryptKey:nil rootPath:nil mode:MMKVSingleProcess
+           expectedCapacity: expectedCapacity];
+}
+
 + (instancetype)mmkvWithID:(NSString *)mmapID mode:(MMKVMode)mode {
     auto rootPath = (mode == MMKVSingleProcess) ? nil : g_groupPath;
     return [MMKV mmkvWithID:mmapID cryptKey:nil rootPath:rootPath mode:mode];
@@ -162,6 +167,10 @@ static BOOL g_hasCalledInitializeMMKV = NO;
 
 + (instancetype)mmkvWithID:(NSString *)mmapID cryptKey:(NSData *)cryptKey {
     return [MMKV mmkvWithID:mmapID cryptKey:cryptKey rootPath:nil mode:MMKVSingleProcess];
+}
+
++ (instancetype)mmkvWithID:(NSString *)mmapID cryptKey:(NSData *)cryptKey expectedCapacity:(size_t)expectedCapacity {
+    return [MMKV mmkvWithID:mmapID cryptKey:cryptKey rootPath:nil mode:MMKVSingleProcess expectedCapacity:expectedCapacity];
 }
 
 + (instancetype)mmkvWithID:(NSString *)mmapID cryptKey:(nullable NSData *)cryptKey mode:(MMKVMode)mode {
@@ -173,6 +182,10 @@ static BOOL g_hasCalledInitializeMMKV = NO;
     return [MMKV mmkvWithID:mmapID cryptKey:nil rootPath:rootPath mode:MMKVSingleProcess];
 }
 
++ (instancetype)mmkvWithID:(NSString *)mmapID rootPath:(nullable NSString *)rootPath expectedCapacity:(size_t)expectedCapacity {
+    return [MMKV mmkvWithID:mmapID cryptKey:nil rootPath:rootPath mode:MMKVSingleProcess expectedCapacity:expectedCapacity];
+}
+
 + (instancetype)mmkvWithID:(NSString *)mmapID relativePath:(nullable NSString *)relativePath {
     return [MMKV mmkvWithID:mmapID cryptKey:nil rootPath:relativePath mode:MMKVSingleProcess];
 }
@@ -181,12 +194,20 @@ static BOOL g_hasCalledInitializeMMKV = NO;
     return [MMKV mmkvWithID:mmapID cryptKey:cryptKey rootPath:rootPath mode:MMKVSingleProcess];
 }
 
++ (instancetype)mmkvWithID:(NSString *)mmapID cryptKey:(nullable NSData *)cryptKey rootPath:(nullable NSString *)rootPath expectedCapacity:(size_t)expectedCapacity {
+    return [MMKV mmkvWithID:mmapID cryptKey:cryptKey rootPath:rootPath mode:MMKVSingleProcess expectedCapacity:expectedCapacity];
+}
+
 + (instancetype)mmkvWithID:(NSString *)mmapID cryptKey:(nullable NSData *)cryptKey relativePath:(nullable NSString *)relativePath {
     return [MMKV mmkvWithID:mmapID cryptKey:cryptKey rootPath:relativePath mode:MMKVSingleProcess];
 }
 
 // relatePath and MMKVMultiProcess mode can't be set at the same time, so we hide this method from public
 + (instancetype)mmkvWithID:(NSString *)mmapID cryptKey:(NSData *)cryptKey rootPath:(nullable NSString *)rootPath mode:(MMKVMode)mode {
+    return [MMKV mmkvWithID:mmapID cryptKey:cryptKey rootPath:rootPath mode:MMKVSingleProcess expectedCapacity: 0];
+}
+
++ (instancetype)mmkvWithID:(NSString *)mmapID cryptKey:(NSData *)cryptKey rootPath:(nullable NSString *)rootPath mode:(MMKVMode)mode expectedCapacity:(size_t)expectedCapacity {
     NSAssert(g_hasCalledInitializeMMKV, @"MMKV not initialized properly, must call +initializeMMKV: in main thread before calling any other MMKV methods");
     if (mmapID.length <= 0) {
         return nil;
@@ -206,7 +227,7 @@ static BOOL g_hasCalledInitializeMMKV = NO;
     NSString *kvKey = [MMKV mmapKeyWithMMapID:mmapID rootPath:rootPath];
     MMKV *kv = [g_instanceDic objectForKey:kvKey];
     if (kv == nil) {
-        kv = [[MMKV alloc] initWithMMapID:mmapID cryptKey:cryptKey rootPath:rootPath mode:mode];
+        kv = [[MMKV alloc] initWithMMapID:mmapID cryptKey:cryptKey rootPath:rootPath mode:mode expectedCapacity:expectedCapacity];
         if (!kv->m_mmkv) {
             [kv release];
             return nil;
@@ -219,7 +240,7 @@ static BOOL g_hasCalledInitializeMMKV = NO;
     return kv;
 }
 
-- (instancetype)initWithMMapID:(NSString *)mmapID cryptKey:(NSData *)cryptKey rootPath:(NSString *)rootPath mode:(MMKVMode)mode {
+- (instancetype)initWithMMapID:(NSString *)mmapID cryptKey:(NSData *)cryptKey rootPath:(NSString *)rootPath mode:(MMKVMode)mode expectedCapacity:(size_t)expectedCapacity {
     if (self = [super init]) {
         string pathTmp;
         if (rootPath.length > 0) {
@@ -231,7 +252,7 @@ static BOOL g_hasCalledInitializeMMKV = NO;
         }
         string *rootPathPtr = pathTmp.empty() ? nullptr : &pathTmp;
         string *cryptKeyPtr = cryptKeyTmp.empty() ? nullptr : &cryptKeyTmp;
-        m_mmkv = mmkv::MMKV::mmkvWithID(mmapID.UTF8String, (mmkv::MMKVMode) mode, cryptKeyPtr, rootPathPtr);
+        m_mmkv = mmkv::MMKV::mmkvWithID(mmapID.UTF8String, (mmkv::MMKVMode) mode, cryptKeyPtr, rootPathPtr, expectedCapacity);
         if (!m_mmkv) {
             return self;
         }

--- a/iOS/MMKVDemo/MMKVDemo/ViewController.mm
+++ b/iOS/MMKVDemo/MMKVDemo/ViewController.mm
@@ -91,6 +91,7 @@
     // [self testMultiProcess];
     [self testBackup];
     [self testRestore];
+    [self testExpectedCapacity];
 
     m_loops = 10000;
     m_arrStrings = [NSMutableArray arrayWithCapacity:m_loops];
@@ -854,6 +855,23 @@ MMKV *getMMKVForBatchTest() {
         restoredKV = [MMKV mmkvWithID:@"testSwift"];
         NSLog(@"check on restore file[%@] keys:%@", restoredKV.mmapID, [restoredKV allKeys]);
     }
+}
+
+
+#pragma mark - expected capacity
+- (void)testExpectedCapacity {
+    
+    auto mmkv = [MMKV mmkvWithID:@"expectedCapacityTest0"];
+    size_t size = [mmkv totalSize];
+    
+    auto mmkv0 = [MMKV mmkvWithID:@"expectedCapacityTest0" expectedCapacity:0];
+    NSLog(@"MMKV file totalSize = %ld", [mmkv0 totalSize]);
+    
+    auto mmkv1 = [MMKV mmkvWithID:@"expectedCapacityTest1" expectedCapacity:size + 1];
+    NSLog(@"MMKV file totalSize = %ld", [mmkv1 totalSize]);
+    
+    auto mmkv3 = [MMKV mmkvWithID:@"expectedCapacityTest3" expectedCapacity:size - 1];
+    NSLog(@"MMKV file totalSize = %ld", [mmkv3 totalSize]);
 }
 
 @end

--- a/iOS/MMKVDemo/MMKVMacDemo/ViewController.mm
+++ b/iOS/MMKVDemo/MMKVMacDemo/ViewController.mm
@@ -19,6 +19,8 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    
+    [self expectedCapacityTest];
 
     [self funcionalTest:NO];
     [self testNeedLoadFromFile];
@@ -37,6 +39,18 @@
         NSString *intKey = [NSString stringWithFormat:@"int-%zu", index];
         [m_arrIntKeys addObject:intKey];
     }
+}
+
+- (void)expectedCapacityTest {
+    auto mmkv0 = [MMKV mmkvWithID:@"expectedCapacityTest0" expectedCapacity:0];
+    NSAssert([mmkv0 totalSize] == PAGE_SIZE, @"expectedCapacityTest Failed to set capacity for mmkv0");
+    
+    auto mmkv1 = [MMKV mmkvWithID:@"expectedCapacityTest1" expectedCapacity:PAGE_SIZE + 1];
+    NSAssert([mmkv1 totalSize] == PAGE_SIZE << 1, @"expectedCapacityTest Failed to set capacity for mmkv1");
+
+    auto mmkv3 = [MMKV mmkvWithID:@"expectedCapacityTest3" expectedCapacity:PAGE_SIZE];
+    NSAssert([mmkv3 totalSize] == PAGE_SIZE, @"expectedCapacityTest Failed to set capacity for mmkv31");
+
 }
 
 - (void)funcionalTest:(BOOL)decodeOnly {


### PR DESCRIPTION
When I add tests for this issue for iOS and Mac, I want to have a function which can really close an instance, instead of just remove it from g_dict.

In another word, at the present,  it will crash when reopening an ID after close it.

```
   // clear expectedCapacityTest2 first
    auto mmkv2 = [MMKV mmkvWithID:@"expectedCapacityTest2"];
    [mmkv2 clearAll];
    [mmkv2 trim];
    [mmkv2 close];

    mmkv2 = [MMKV mmkvWithID:@"expectedCapacityTest2" expectedCapacity:PAGE_SIZE - 1];

   [mmkv2 do something] // will crash...

```
**code above crashes when reopen a closed MMKV instance** 

But in Android:
```
MMKV.initialize(this);
MMKV mmkv = MMKV.defaultMMKV();
mmkv.putString("a", "bbbb");
// mmkv.trim();
// mmkv.close();
mmkv.close();
mmkv = MMKV.defaultMMKV();
Log.e("lishaokai", "" + mmkv.getString("a", "?"));
```

it works
So i have a doubt that close function in OC have something wrong 
