### PR TITLE
Fix lint error related to usage of getColumnIndex

### DIFF
--- a/Android/MMKV/mmkvdemo/src/main/java/com/tencent/mmkvdemo/SQLiteKV.java
+++ b/Android/MMKV/mmkvdemo/src/main/java/com/tencent/mmkvdemo/SQLiteKV.java
@@ -116,7 +116,7 @@ public final class SQLiteKV {
         Cursor cursor = getReadableDatabase().rawQuery(
             "select v from " + SQLiteKVDBHelper.TABLE_NAME_INT + " where k=?", new String[] {key});
         if (cursor.moveToFirst()) {
-            value = cursor.getInt(cursor.getColumnIndex("v"));
+            value = cursor.getInt(cursor.getColumnIndexOrThrow("v"));
         }
         cursor.close();
         return value;
@@ -135,7 +135,7 @@ public final class SQLiteKV {
         Cursor cursor = getReadableDatabase().rawQuery(
             "select v from " + SQLiteKVDBHelper.TABLE_NAME_STR + " where k=?", new String[] {key});
         if (cursor.moveToFirst()) {
-            value = cursor.getString(cursor.getColumnIndex("v"));
+            value = cursor.getString(cursor.getColumnIndexOrThrow("v"));
         }
         cursor.close();
         return value;


### PR DESCRIPTION
### Summary
It's just to fix the lint error related to the usage of `getColumnIndex`. Use `getColumnIndexOrThrow` instead to avoid the issue.

`getColumnIndex` may return `-1` while `getColumnIndexOrThrow` won't.

### Testing
* `./gradlew build`