### PR TITLE
override from beginning of file when dict is empty

### DIFF
--- a/Core/MMKV_IO.cpp
+++ b/Core/MMKV_IO.cpp
@@ -617,7 +617,13 @@ bool MMKV::setDataForKey(MMBuffer &&data, MMKVKey_t key, bool isDataHolder) {
                 }
             }
         } else {
-            auto ret = appendDataWithKey(data, key, isDataHolder);
+            bool needOverride = !m_isInterProcess && m_dicCrypt->empty() && m_actualSize > 0;
+            KVHolderRet_t ret;
+            if (needOverride) {
+                ret = overrideDataWithKey(data, key, isDataHolder);
+            } else {
+                ret = appendDataWithKey(data, key, isDataHolder);
+            }
             if (!ret.first) {
                 return false;
             }
@@ -669,7 +675,13 @@ bool MMKV::setDataForKey(MMBuffer &&data, MMKVKey_t key, bool isDataHolder) {
                 }
             }
         } else {
-            auto ret = appendDataWithKey(data, key, isDataHolder);
+            bool needOverride = !m_isInterProcess && m_dic->empty() && m_actualSize > 0;
+            KVHolderRet_t ret;
+            if (needOverride) {
+                ret = overrideDataWithKey(data, key, isDataHolder);
+            } else {
+                ret = appendDataWithKey(data, key, isDataHolder);
+            }
             if (!ret.first) {
                 return false;
             }

--- a/POSIX/demo/demo.cpp
+++ b/POSIX/demo/demo.cpp
@@ -517,6 +517,109 @@ void testOnlyOneKey() {
     }
 }
 
+void testOverride() {
+    string key1 = "key1";
+    string key2 = "key2";
+    string key3 = "key3";
+    string s;
+    {
+        s = "";
+        auto mmkv = MMKV::mmkvWithID("testOverride");
+
+        mmkv->set("world1", key1);
+        mmkv->getString(key1, s);
+        printf("testOverride: key1 = %s\n", s.c_str());
+
+        mmkv->set("world2", key2);
+        mmkv->getString(key2, s);
+        printf("testOverride: key2 = %s\n", s.c_str());
+
+        mmkv->removeValueForKey(key1);
+        mmkv->removeValueForKey(key2);
+
+        printf("testOverride: actualSize = %lu\n", mmkv->actualSize());
+
+        mmkv->set("world3", key3);
+        mmkv->getString(key3, s);
+        printf("testOverride: key3 = %s\n", s.c_str());
+        printf("testOverride: actualSize = %lu\n", mmkv->actualSize());
+
+        mmkv->removeValueForKey(key3);
+
+        // test file expanding
+        string bigValue(100000, '0');
+        mmkv->set(bigValue, key1);
+        mmkv->getString(key1, s);
+        assert(s == bigValue);
+
+        mmkv->removeValueForKey(key1);
+
+        mmkv->set("OK", key2);
+        mmkv->getString(key2, s);
+        printf("testOverride: value = %s\n", s.c_str());
+
+        // close it and reopen it
+        mmkv->close();
+        mmkv = MMKV::mmkvWithID("testOverride");
+        mmkv->getString(key2, s);
+        printf("testOverride: after reopen key2 = %s\n", s.c_str());
+        assert(s == "OK");
+
+        mmkv->removeValueForKey(key2);
+        mmkv->trim();
+    }
+
+    {
+        s = "";
+        string cryptKey = "fastest2";
+        auto mmkv = MMKV::mmkvWithID("testOverrideCrypt", MMKV_SINGLE_PROCESS, &cryptKey);
+        mmkv->enableAutoKeyExpire(24 * 60 * 60);
+
+        mmkv->set("world1", key1);
+        mmkv->getString(key1, s);
+        printf("testOverrideCrypt: key1 = %s\n", s.c_str());
+
+        mmkv->set("world2", key2);
+        mmkv->getString(key2, s);
+        printf("testOverrideCrypt: key2 = %s\n", s.c_str());
+
+        mmkv->removeValueForKey(key1);
+        mmkv->removeValueForKey(key2);
+
+        printf("testOverrideCrypt: actualSize = %lu\n", mmkv->actualSize());
+
+        mmkv->set("world3", key3);
+        mmkv->getString(key3, s);
+        printf("testOverrideCrypt: key3 = %s\n", s.c_str());
+        printf("testOverrideCrypt: actualSize = %lu\n", mmkv->actualSize());
+
+        mmkv->removeValueForKey(key3);
+
+        // test file expanding
+        string bigValue(100000, '0');
+        mmkv->set(bigValue, key1);
+        mmkv->getString(key1, s);
+        assert(s == bigValue);
+
+        mmkv->removeValueForKey(key1);
+
+        mmkv->set("OK", key2);
+        mmkv->getString(key2, s);
+        printf("testOverrideCrypt: value = %s\n", s.c_str());
+
+        // close it and reopen it
+        mmkv->close();
+        mmkv = MMKV::mmkvWithID("testOverrideCrypt", MMKV_SINGLE_PROCESS, &cryptKey);
+        mmkv->getString(key2, s);
+        printf("testOverrideCrypt: after reopen key2 = %s\n", s.c_str());
+        assert(s == "OK");
+
+        mmkv->removeValueForKey(key2);
+        mmkv->trim();
+    }
+
+}
+
 void MyLogHandler(MMKVLogLevel level, const char *file, int line, const char *function, const string &message) {
 
     auto desc = [level] {
@@ -566,6 +669,7 @@ int main() {
     testInterProcessLock();
     testExpectedCapacity();
     testOnlyOneKey();
+    testOverride();
     testBackup();
     testRestore();
     testAutoExpiration();

--- a/iOS/MMKVDemo/MMKVDemo/ViewController.mm
+++ b/iOS/MMKVDemo/MMKVDemo/ViewController.mm
@@ -93,6 +93,7 @@
     [self testRestore];
     [self testExpectedCapacity];
     [self onlyOneKeyTest];
+    [self overrideTest];
 
     m_loops = 10000;
     m_arrStrings = [NSMutableArray arrayWithCapacity:m_loops];
@@ -889,6 +890,71 @@ MMKV *getMMKVForBatchTest() {
     for (int i = 0; i < count; i++) {
         // 0 times expand
         [mmkv1 setString:value forKey:[NSString stringWithFormat:@"key%d", i]];
+    }
+}
+
+
+- (void) overrideTest {
+    {
+        auto mmkv0 = [MMKV mmkvWithID:@"overrideTest"];
+        NSString *key = [NSString stringWithFormat:@"hello"];
+        NSString *key2 = [NSString stringWithFormat:@"hello2"];
+        NSString *value = [NSString stringWithFormat:@"world"];
+        
+        [mmkv0 setString:value forKey:key];
+        auto v2 = [mmkv0 getStringForKey:key];
+        NSLog(@"value = %@", v2);
+        [mmkv0 removeValueForKey:key];
+        
+        [mmkv0 setString:value forKey:key2];
+        v2 = [mmkv0 getStringForKey:key2];
+        NSLog(@"value = %@", v2);
+        [mmkv0 removeValueForKey:key2];
+        
+        int len = 10000;
+        NSMutableString *bigValue = [NSMutableString stringWithFormat:@"🏊🏻®4️⃣🐅_"];
+        for (int i = 0; i < len; i++) {
+            [bigValue appendString:@"0"];
+        }
+        [mmkv0 setString:bigValue forKey:key];
+        auto v3 = [mmkv0 getStringForKey:key];
+        // NSLog(@"value = %@", v3);
+        if (![bigValue isEqualToString:v3]) {
+            abort();
+        }
+
+        // rewrite
+        [mmkv0 setString:@"OK" forKey:key];
+        auto v4 = [mmkv0 getStringForKey:key];
+        NSLog(@"value = %@", v4);
+        
+        [mmkv0 setInt32:12345 forKey:@"int"];
+        auto v5 = [mmkv0 getInt32ForKey:key];
+        NSLog(@"int value = %d", v5);
+        [mmkv0 removeValueForKey:@"int"];
+        
+        [mmkv0 clearAll];
+    
+    }
+    
+    {
+        NSString *crypt = [NSString stringWithFormat:@"fastestCrypt"];
+        auto mmkv0 = [MMKV mmkvWithID:@"overrideCryptTest" cryptKey:[crypt dataUsingEncoding:NSUTF8StringEncoding] mode:MMKVSingleProcess];
+        NSString *key = [NSString stringWithFormat:@"hello"];
+        NSString *key2 = [NSString stringWithFormat:@"hello2"];
+        NSString *value = [NSString stringWithFormat:@"cryptworld"];
+        
+        [mmkv0 setString:value forKey:key];
+        auto v2 = [mmkv0 getStringForKey:key];
+        NSLog(@"value = %@", v2);
+        
+        [mmkv0 removeValueForKey:key];
+        [mmkv0 setString:value forKey:key2];
+        v2 = [mmkv0 getStringForKey:key2];
+        NSLog(@"value = %@", v2);
+        [mmkv0 removeValueForKey:key2];
+        
+        [mmkv0 clearAll];
     }
 }
 

--- a/iOS/MMKVDemo/MMKVMacDemo/ViewController.mm
+++ b/iOS/MMKVDemo/MMKVMacDemo/ViewController.mm
@@ -19,9 +19,9 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    
+
     [self onlyOneKeyTest];
-    
+    [self overrideTest];
     [self expectedCapacityTest];
 
     [self funcionalTest:NO];
@@ -102,6 +102,70 @@
             auto v2 = [mmkv0 getStringForKey:key];
             NSLog(@"value = %@", v2);
         }
+    }
+}
+
+- (void) overrideTest {
+    {
+        auto mmkv0 = [MMKV mmkvWithID:@"overrideTest"];
+        NSString *key = [NSString stringWithFormat:@"hello"];
+        NSString *key2 = [NSString stringWithFormat:@"hello2"];
+        NSString *value = [NSString stringWithFormat:@"world"];
+        
+        [mmkv0 setString:value forKey:key];
+        auto v2 = [mmkv0 getStringForKey:key];
+        NSLog(@"value = %@", v2);
+        [mmkv0 removeValueForKey:key];
+        
+        [mmkv0 setString:value forKey:key2];
+        v2 = [mmkv0 getStringForKey:key2];
+        NSLog(@"value = %@", v2);
+        [mmkv0 removeValueForKey:key2];
+        
+        int len = 10000;
+        NSMutableString *bigValue = [NSMutableString stringWithFormat:@"🏊🏻®4️⃣🐅_"];
+        for (int i = 0; i < len; i++) {
+            [bigValue appendString:@"0"];
+        }
+        [mmkv0 setString:bigValue forKey:key];
+        auto v3 = [mmkv0 getStringForKey:key];
+        // NSLog(@"value = %@", v3);
+        if (![bigValue isEqualToString:v3]) {
+            abort();
+        }
+
+        // rewrite
+        [mmkv0 setString:@"OK" forKey:key];
+        auto v4 = [mmkv0 getStringForKey:key];
+        NSLog(@"value = %@", v4);
+        
+        [mmkv0 setInt32:12345 forKey:@"int"];
+        auto v5 = [mmkv0 getInt32ForKey:key];
+        NSLog(@"int value = %d", v5);
+        [mmkv0 removeValueForKey:@"int"];
+        
+        [mmkv0 clearAll];
+    
+    }
+    
+    {
+        NSString *crypt = [NSString stringWithFormat:@"fastestCrypt"];
+        auto mmkv0 = [MMKV mmkvWithID:@"overrideCryptTest" cryptKey:[crypt dataUsingEncoding:NSUTF8StringEncoding] mode:MMKVSingleProcess];
+        NSString *key = [NSString stringWithFormat:@"hello"];
+        NSString *key2 = [NSString stringWithFormat:@"hello2"];
+        NSString *value = [NSString stringWithFormat:@"cryptworld"];
+        
+        [mmkv0 setString:value forKey:key];
+        auto v2 = [mmkv0 getStringForKey:key];
+        NSLog(@"value = %@", v2);
+        
+        [mmkv0 removeValueForKey:key];
+        [mmkv0 setString:value forKey:key2];
+        v2 = [mmkv0 getStringForKey:key2];
+        NSLog(@"value = %@", v2);
+        [mmkv0 removeValueForKey:key2];
+        
+        [mmkv0 clearAll];
     }
 }
 


### PR DESCRIPTION
If we add some key-value and remove them ALL, then add a new key-value, MAYBE it is better to write from beginning of file