### PR TITLE
compare value before set/encode for the same key

### DIFF
--- a/Android/MMKV/mmkv/src/main/cpp/native-bridge.cpp
+++ b/Android/MMKV/mmkv/src/main/cpp/native-bridge.cpp
@@ -1014,6 +1014,44 @@ MMKV_JNI jboolean disableAutoExpire(JNIEnv *env, jobject instance) {
     return (jboolean) false;
 }
 
+MMKV_JNI void enableCompareBeforeSet(JNIEnv *env, jobject instance) {
+    MMKV *kv = getMMKV(env, instance);
+    if (kv) {
+        kv->enableCompareBeforeSet();
+    }
+}
+
+MMKV_JNI void disableCompareBeforeSet(JNIEnv *env, jobject instance) {
+    MMKV *kv = getMMKV(env, instance);
+    if (kv) {
+        kv->disableCompareBeforeSet();
+    }
+}
+
+MMKV_JNI bool isCompareBeforeSetEnabled(JNIEnv *env, jobject instance) {
+    MMKV *kv = getMMKV(env, instance);
+    if (kv) {
+        return kv->isCompareBeforeSetEnabled();
+    }
+    return false;
+}
+
+MMKV_JNI bool isEncryptionEnabled(JNIEnv *env, jobject instance) {
+    MMKV *kv = getMMKV(env, instance);
+    if (kv) {
+        return kv->isEncryptionEnabled();
+    }
+    return false;
+}
+
+MMKV_JNI bool isExpirationEnabled(JNIEnv *env, jobject instance) {
+    MMKV *kv = getMMKV(env, instance);
+    if (kv) {
+        return kv->isExpirationEnabled();
+    }
+    return false;
+}
+
 } // namespace mmkv
 
 static JNINativeMethod g_methods[] = {
@@ -1089,6 +1127,11 @@ static JNINativeMethod g_methods[] = {
     {"restoreAllFromDirectory", "(Ljava/lang/String;)J", (void *) mmkv::restoreAll},
     {"enableAutoKeyExpire", "(I)Z", (void *) mmkv::enableAutoExpire},
     {"disableAutoKeyExpire", "()Z", (void *) mmkv::disableAutoExpire},
+    {"nativeEnableCompareBeforeSet", "()V", (void *) mmkv::enableCompareBeforeSet},
+    {"disableCompareBeforeSet", "()V", (void *) mmkv::disableCompareBeforeSet},
+    {"isCompareBeforeSetEnabled", "()Z", (void *) mmkv::isCompareBeforeSetEnabled},
+    {"isEncryptionEnabled", "()Z", (void *) mmkv::isEncryptionEnabled},
+    {"isExpirationEnabled", "()Z", (void *) mmkv::isExpirationEnabled},
 };
 
 static int registerNativeMethods(JNIEnv *env, jclass cls) {

--- a/Android/MMKV/mmkvdemo/src/main/java/com/tencent/mmkvdemo/MainActivity.java
+++ b/Android/MMKV/mmkvdemo/src/main/java/com/tencent/mmkvdemo/MainActivity.java
@@ -124,6 +124,52 @@ public class MainActivity extends AppCompatActivity {
 
         testAutoExpire();
         testExpectedCapacity();
+        testCompareBeforeSet();
+    }
+
+    private void testCompareBeforeSet() {
+        MMKV mmkv = MMKV.mmkvWithID("testCompareBeforeSet");
+        mmkv.enableCompareBeforeSet();
+
+        mmkv.encode("key", "extra");
+
+        {
+            String key = "int";
+            int v = 12345;
+            mmkv.encode(key, v);
+            long actualSize = mmkv.actualSize();
+            Log.d("mmkv", "testCompareBeforeSet actualSize = " + actualSize);
+            Log.d("mmkv", "testCompareBeforeSet v = " + mmkv.getInt(key, -1));
+            mmkv.encode(key, v);
+            long actualSize2 = mmkv.actualSize();
+            Log.d("mmkv", "testCompareBeforeSet actualSize = " + actualSize2);
+            if (actualSize2 != actualSize) {
+                Log.e("mmkv", "testCompareBeforeSet fail");
+            }
+
+            mmkv.encode(key, v * 23);
+            Log.d("mmkv", "testCompareBeforeSet actualSize = " + mmkv.actualSize());
+            Log.d("mmkv", "testCompareBeforeSet v = " + mmkv.getInt(key, -1));
+        }
+
+        {
+            String key = "string";
+            String v = "w012A🏊🏻good";
+            mmkv.encode(key, v);
+            long actualSize = mmkv.actualSize();
+            Log.d("mmkv", "testCompareBeforeSet actualSize = " + actualSize);
+            Log.d("mmkv", "testCompareBeforeSet v = " + mmkv.getString(key, ""));
+            mmkv.encode(key, v);
+            long actualSize2 = mmkv.actualSize();
+            Log.d("mmkv", "testCompareBeforeSet actualSize = " + actualSize2);
+            if (actualSize2 != actualSize) {
+                Log.e("mmkv", "testCompareBeforeSet fail");
+            }
+
+            mmkv.encode(key, "temp data 👩🏻‍🏫");
+            Log.d("mmkv", "testCompareBeforeSet actualSize = " + mmkv.actualSize());
+            Log.d("mmkv", "testCompareBeforeSet v = " + mmkv.getString(key, ""));
+        }
     }
 
     private void testInterProcessLogic() {
@@ -638,6 +684,8 @@ public class MainActivity extends AppCompatActivity {
         mmkv.enableAutoKeyExpire(1);
         mmkv.encode("auto_expire_key_1", true);
         mmkv.encode("never_expire_key_1", true, MMKV.ExpireNever);
+
+//        mmkv.enableCompareBeforeSet();
 
         testAutoExpire(mmkv, false, 1);
         SystemClock.sleep(1000 * 2);

--- a/Core/CodedInputData.h
+++ b/Core/CodedInputData.h
@@ -64,8 +64,11 @@ public:
 
     uint32_t readUInt32();
 
-    MMBuffer readData();
+    // exactly is like getValueSize(actualSize = true)
+    MMBuffer readData(bool copy = true, bool exactly = false);
     void readData(KeyValueHolder &kvHolder);
+
+    static MMBuffer readRealData(mmkv::MMBuffer & data);
 
 #ifndef MMKV_APPLE
     std::string readString();

--- a/Core/MMBuffer.cpp
+++ b/Core/MMBuffer.cpp
@@ -84,6 +84,13 @@ MMBuffer::MMBuffer(void *source, size_t length, MMBufferCopyFlag flag) : isNoCop
     }
 }
 
+bool MMBuffer::operator==(const MMBuffer& other) const {
+    if (this->length() != other.length()) {
+        return false;
+    }
+    return !memcmp((uint8_t*)this->getPtr(), (uint8_t*)other.getPtr(), this->length());
+}
+
 #ifdef MMKV_APPLE
 MMBuffer::MMBuffer(NSData *data, MMBufferCopyFlag flag)
     : type(MMBufferType_Normal), ptr((void *) data.bytes), size(data.length), isNoCopy(flag) {

--- a/Core/MMBuffer.h
+++ b/Core/MMBuffer.h
@@ -91,6 +91,9 @@ public:
     // transfer ownership to others
     void detach();
 
+    // compare two MMBuffer
+    bool operator==(const MMBuffer& other) const;
+
     // those are expensive, just forbid it for possibly misuse
     explicit MMBuffer(const MMBuffer &other) = delete;
     MMBuffer &operator=(const MMBuffer &other) = delete;

--- a/Core/MMKV.h
+++ b/Core/MMKV.h
@@ -23,6 +23,7 @@
 #ifdef  __cplusplus
 
 #include "MMBuffer.h"
+#include "PBUtility.h"
 #include <cstdint>
 
 namespace mmkv {
@@ -93,6 +94,8 @@ class MMKV {
 
     bool m_enableKeyExpire = false;
     uint32_t m_expiredInSeconds = ExpireNever;
+
+    bool m_enableCompareBeforeSet = false;
 
 #ifdef MMKV_APPLE
     using MMKVKey_t = NSString *__unsafe_unretained;
@@ -336,6 +339,15 @@ public:
     bool enableAutoKeyExpire(uint32_t expiredInSeconds = 0);
 
     bool disableAutoKeyExpire();
+
+
+    // compare value for key before set, to reduce the possibility of file expanding
+    void enableCompareBeforeSet();
+    void disableCompareBeforeSet();
+    
+    bool isExpirationEnabled() { return m_enableKeyExpire; }
+    bool isEncryptionEnabled() { return m_dicCrypt; }
+    bool isCompareBeforeSetEnabled() { return m_enableCompareBeforeSet && likely(!m_enableKeyExpire) && likely(!m_dicCrypt); }
 
 #ifdef MMKV_APPLE
     // filterExpire: return all non-expired keys, keep in mind it comes with cost

--- a/iOS/MMKV/MMKV/MMKV.h
+++ b/iOS/MMKV/MMKV/MMKV.h
@@ -261,10 +261,20 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray *)allNonExpiredKeys;
 
 /// all keys created (or last modified) longger than expiredInSeconds will be deleted on next full-write-back
+/// enableCompareBeforeSet will be invalid when Expiration is on
 /// @param expiredInSeconds = MMKVExpireNever (0) means no common expiration duration for all keys, aka each key will have it's own expiration duration
 - (BOOL)enableAutoKeyExpire:(uint32_t) expiredInSeconds NS_SWIFT_NAME(enableAutoKeyExpire(expiredInSeconds:));
 
 - (BOOL)disableAutoKeyExpire;
+
+/// Enable data compare before set, for better performance
+/// If data for key seldom changes, use it
+/// Notice: When encryption or expiration is on, compare-before-set will be invalid.
+/// For encryption, compare operation must decrypt data which is time consuming
+/// For expiration, compare is useless because in most cases the expiration time changes every time.
+- (void)enableCompareBeforeSet;
+
+- (void)disableCompareBeforeSet;
 
 - (void)removeValueForKey:(NSString *)key NS_SWIFT_NAME(removeValue(forKey:));
 

--- a/iOS/MMKV/MMKV/libMMKV.mm
+++ b/iOS/MMKV/MMKV/libMMKV.mm
@@ -650,11 +650,40 @@ static BOOL g_hasCalledInitializeMMKV = NO;
 }
 
 - (BOOL)enableAutoKeyExpire:(uint32_t) expiredInSeconds {
+    if (m_mmkv->isCompareBeforeSetEnabled()) {
+        MMKVWarning("enableCompareBeforeSet will be invalid when Expiration is on");
+# if DEBUG
+        MMKV_ASSERT(0);
+# endif
+    }
     return m_mmkv->enableAutoKeyExpire(expiredInSeconds);
 }
 
 - (BOOL)disableAutoKeyExpire {
     return m_mmkv->disableAutoKeyExpire();
+}
+
+- (void)enableCompareBeforeSet {
+    if (m_mmkv->isExpirationEnabled()) {
+        MMKVWarning("enableCompareBeforeSet is invalid when Expiration is on");
+# if DEBUG
+        MMKV_ASSERT(0);
+# endif
+        return;
+    }
+    if (m_mmkv->isEncryptionEnabled()) {
+        MMKVWarning("enableCompareBeforeSet is invalid when key encryption is on");
+# if DEBUG
+        MMKV_ASSERT(0);
+# endif
+        return;
+    }
+    
+    return m_mmkv->enableCompareBeforeSet();
+}
+
+- (void)disableCompareBeforeSet {
+    return m_mmkv->disableCompareBeforeSet();
 }
 
 - (void)removeValueForKey:(NSString *)key {

--- a/iOS/MMKVDemo/MMKVDemo/ViewController.mm
+++ b/iOS/MMKVDemo/MMKVDemo/ViewController.mm
@@ -94,6 +94,7 @@
     [self testExpectedCapacity];
     [self onlyOneKeyTest];
     [self overrideTest];
+    [self testCompareBeforeSet];
 
     m_loops = 10000;
     m_arrStrings = [NSMutableArray arrayWithCapacity:m_loops];
@@ -1031,6 +1032,48 @@ MMKV *getMMKVForBatchTest() {
             auto v2 = [mmkv1 getStringForKey:key];
             NSLog(@"value = %@", v2);
         }
+    }
+}
+
+- (void) testCompareBeforeSet {
+    auto mmkv = [MMKV mmkvWithID:@"testCompareBeforeSet"];
+    [mmkv enableCompareBeforeSet];
+    [mmkv setBool:true forKey:@"extra"];
+    
+    {
+        NSString *key = @"int64";
+        int64_t v = 123456L;
+        [mmkv setInt64:v forKey:key];
+        long actualSize = [mmkv actualSize];
+        NSLog(@"testCompareBeforeSet actualSize = %ld", actualSize);
+        NSLog(@"testCompareBeforeSet v = %lld", [mmkv getInt64ForKey:key]);
+        [mmkv setInt64:v forKey:key];
+        long actualSize2 = [mmkv actualSize];
+        NSLog(@"testCompareBeforeSet actualSize = %ld", actualSize2);
+        if (actualSize != actualSize2) {
+            abort();
+        }
+        [mmkv setInt64:v << 1 forKey:key];
+        NSLog(@"testCompareBeforeSet actualSize = %ld", [mmkv actualSize]);
+        NSLog(@"testCompareBeforeSet v = %lld", [mmkv getInt64ForKey:key]);
+    }
+    
+    {
+        NSString *key = @"string";
+        NSString *v = [NSString stringWithFormat:@"w012A🏊🏻good"];
+        [mmkv setString:v forKey:key];
+        long actualSize = [mmkv actualSize];
+        NSLog(@"testCompareBeforeSet actualSize = %ld", actualSize);
+        NSLog(@"testCompareBeforeSet v = %@", [mmkv getStringForKey:key]);
+        [mmkv setString:v forKey:key];
+        long actualSize2 = [mmkv actualSize];
+        NSLog(@"testCompareBeforeSet actualSize = %ld", actualSize2);
+        if (actualSize != actualSize2) {
+            abort();
+        }
+        [mmkv setString:@"another string" forKey:key];
+        NSLog(@"testCompareBeforeSet actualSize = %ld", [mmkv actualSize]);
+        NSLog(@"testCompareBeforeSet v = %@", [mmkv getStringForKey:key]);
     }
 }
 

--- a/iOS/MMKVDemo/MMKVMacDemo/ViewController.mm
+++ b/iOS/MMKVDemo/MMKVMacDemo/ViewController.mm
@@ -20,6 +20,8 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
 
+    [self testCompareBeforeSet];
+    
     [self onlyOneKeyTest];
     [self overrideTest];
     [self expectedCapacityTest];
@@ -151,6 +153,7 @@
     {
         NSString *crypt = [NSString stringWithFormat:@"fastestCrypt"];
         auto mmkv0 = [MMKV mmkvWithID:@"overrideCryptTest" cryptKey:[crypt dataUsingEncoding:NSUTF8StringEncoding] mode:MMKVSingleProcess];
+//        [mmkv0 enableCompareBeforeSet];
         NSString *key = [NSString stringWithFormat:@"hello"];
         NSString *key2 = [NSString stringWithFormat:@"hello2"];
         NSString *value = [NSString stringWithFormat:@"cryptworld"];
@@ -192,6 +195,48 @@
     for (int i = 0; i < count; i++) {
         // 0 times expand
         [mmkv1 setString:value forKey:[NSString stringWithFormat:@"key%d", i]];
+    }
+}
+
+- (void) testCompareBeforeSet {
+    auto mmkv = [MMKV mmkvWithID:@"testCompareBeforeSet"];
+    [mmkv enableCompareBeforeSet];
+    [mmkv setBool:true forKey:@"extra"];
+    
+    {
+        NSString *key = @"int64";
+        int64_t v = 123456L;
+        [mmkv setInt64:v forKey:key];
+        long actualSize = [mmkv actualSize];
+        NSLog(@"testCompareBeforeSet actualSize = %ld", actualSize);
+        NSLog(@"testCompareBeforeSet v = %lld", [mmkv getInt64ForKey:key]);
+        [mmkv setInt64:v forKey:key];
+        long actualSize2 = [mmkv actualSize];
+        NSLog(@"testCompareBeforeSet actualSize = %ld", actualSize2);
+        if (actualSize != actualSize2) {
+            abort();
+        }
+        [mmkv setInt64:v << 1 forKey:key];
+        NSLog(@"testCompareBeforeSet actualSize = %ld", [mmkv actualSize]);
+        NSLog(@"testCompareBeforeSet v = %lld", [mmkv getInt64ForKey:key]);
+    }
+    
+    {
+        NSString *key = @"string";
+        NSString *v = [NSString stringWithFormat:@"w012A🏊🏻good"];
+        [mmkv setString:v forKey:key];
+        long actualSize = [mmkv actualSize];
+        NSLog(@"testCompareBeforeSet actualSize = %ld", actualSize);
+        NSLog(@"testCompareBeforeSet v = %@", [mmkv getStringForKey:key]);
+        [mmkv setString:v forKey:key];
+        long actualSize2 = [mmkv actualSize];
+        NSLog(@"testCompareBeforeSet actualSize = %ld", actualSize2);
+        if (actualSize != actualSize2) {
+            abort();
+        }
+        [mmkv setString:@"another string" forKey:key];
+        NSLog(@"testCompareBeforeSet actualSize = %ld", [mmkv actualSize]);
+        NSLog(@"testCompareBeforeSet v = %@", [mmkv getStringForKey:key]);
     }
 }
 


### PR DESCRIPTION
Last pr was closed after resolving conflict. 

old comments is in   [https://github.com/Tencent/MMKV/pull/1166](https://github.com/Tencent/MMKV/pull/1166)


please have a looking at this pr.

Thanks a lot.

===============================================================

`bool MMKV::set(const vector<string> &v, MMKVKey_t key, uint32_t expireDuration);`

This function is an exception.
There are 3 different ways to handle this:

1、ways of this pr, ignoring wrong type, maybe miss one time compare for REAL equal case. BUT have no bad effect for reasults. just one more useless set. better performance.

2、remove compareBeforeSet support for vector<string>

3、call `bool MMKV::getVector(MMKVKey_t key, vector<string> &result)` to get accurate vector, compare with new one. BUT this method are a little time consuming.

what do you prefer?
