### PR TITLE
Fix cgo cannot find functions reference when turn on "MMKV_DISABLE_CRYPT"

### DIFF
--- a/POSIX/golang/golang-bridge.cpp
+++ b/POSIX/golang/golang-bridge.cpp
@@ -390,6 +390,18 @@ MMKV_EXPORT void checkReSetCryptKey(void *handle, GoStringWrap oKey) {
     }
 }
 
+#    else // fix cgo cannot find function reference.
+
+MMKV_EXPORT bool reKey(void *handle, GoStringWrap oKey) {
+    return false;
+}
+
+MMKV_EXPORT void *cryptKey(void *handle, uint32_t *lengthPtr) {
+    return nullptr;
+}
+
+MMKV_EXPORT void checkReSetCryptKey(void *handle, GoStringWrap oKey) {}
+
 #    endif // MMKV_DISABLE_CRYPT
 
 MMKV_EXPORT GoStringWrap *allKeys(void *handle, uint64_t *lengthPtr, bool filterExpire) {


### PR DESCRIPTION
Turn on "MMKV_DISABLE_CRYPT" will not compile passed by `Golang`:
```shell
➜  test git:(dev) ✗ go build -v        
runtime/cgo
tencent.com/mmkv
mmkv_test
# mmkv_test
/usr/local/go/pkg/tool/linux_amd64/link: running /usr/bin/g++ failed: exit status 1
/usr/bin/ld: /tmp/go-link-2434606250/000002.o: in function `_cgo_370889eb6d07_Cfunc_cryptKey':
/tmp/go-build/cgo-gcc-prolog:228: undefined reference to `cryptKey'
/usr/bin/ld: /tmp/go-link-2434606250/000002.o: in function `_cgo_370889eb6d07_Cfunc_reKey':
/tmp/go-build/cgo-gcc-prolog:1004: undefined reference to `reKey'
/usr/bin/ld: /tmp/go-link-2434606250/000002.o: in function `_cgo_370889eb6d07_Cfunc_checkReSetCryptKey':
/tmp/go-build/cgo-gcc-prolog:146: undefined reference to `checkReSetCryptKey'
collect2: error: ld returned 1 exit status

```