### PR TITLE
fix: (POSIX)use of undeclared identifier memcpy

### DIFF
--- a/Core/CodedInputData.cpp
+++ b/Core/CodedInputData.cpp
@@ -21,6 +21,7 @@
 #include "CodedInputData.h"
 #include "PBUtility.h"
 #include <stdexcept>
+#include <cstring>
 
 #ifdef MMKV_APPLE
 #    if __has_feature(objc_arc)


### PR DESCRIPTION
We are using MMKV in WMPF. After upgrading to v1.3.2 the compile process is broken with error message: "use of undeclared identifier memcpy". Fixed with adding a header <cstring>.