### PR TITLE
Fix multiprocess mode on iOS

### DIFF
--- a/iOS/MMKV/MMKV/libMMKV.mm
+++ b/iOS/MMKV/MMKV/libMMKV.mm
@@ -207,9 +207,8 @@ static BOOL g_hasCalledInitializeMMKV = NO;
     return [MMKV mmkvWithID:mmapID cryptKey:cryptKey rootPath:relativePath mode:MMKVSingleProcess];
 }
 
-// relatePath and MMKVMultiProcess mode can't be set at the same time, so we hide this method from public
 + (instancetype)mmkvWithID:(NSString *)mmapID cryptKey:(NSData *)cryptKey rootPath:(nullable NSString *)rootPath mode:(MMKVMode)mode {
-    return [MMKV mmkvWithID:mmapID cryptKey:cryptKey rootPath:rootPath mode:MMKVSingleProcess expectedCapacity:0];
+    return [MMKV mmkvWithID:mmapID cryptKey:cryptKey rootPath:rootPath mode:mode expectedCapacity:0];
 }
 
 + (instancetype)mmkvWithID:(NSString *)mmapID cryptKey:(NSData *)cryptKey rootPath:(nullable NSString *)rootPath mode:(MMKVMode)mode expectedCapacity:(size_t)expectedCapacity {


### PR DESCRIPTION
There is currently no way to enable multiprocess mode on iOS. I was initializing MMKV using the following code (Swift):

<img width="816" alt="Screenshot 2024-01-03 at 11 46 34 AM" src="https://github.com/Tencent/MMKV/assets/377682/a20367ab-075a-4876-8571-293bb856fda5">

Yet, the logs would display the following: 

`
loading [mmkv.default] with 0 actual size, file size 16384, InterProcess 0, meta info version:4
`

Looking at the source code, I found the constructor associated with this class here:

https://github.com/Tencent/MMKV/blob/master/iOS/MMKV/MMKV/libMMKV.mm#L181-L184

this constructor sets rootPath to g_groupPath if mode is not MMKVSingleProcess and calls another (private) constructor 
```objective-c
[MMKV mmkvWithID:mmapID cryptKey:cryptKey rootPath:rootPath mode:mode]
```


Unfortunately, this constructor forces the mode to MMKVSingleProcess, it also does not implement relativePath so the comment isn't relevant anymore.

https://github.com/Tencent/MMKV/blob/master/iOS/MMKV/MMKV/libMMKV.mm#L212

Also there does not seem to be any constructor that let you set both "mode" and "relativePath" anymore so the comment is really not needed.

Looking at all the exported constructors, none of them let you set multi-process mode as they all end up calling the constructor that forces MMKVSingleProcess so I don't think there is currently a way to enable multi-process mode on iOS. I would like to enable this mode mainly for sharing data with my iOS widgets.