### PR TITLE
bugfix: trim sigbus

### DIFF
--- a/Core/MMKV_IO.cpp
+++ b/Core/MMKV_IO.cpp
@@ -1388,6 +1388,7 @@ void MMKV::trim() {
     SCOPED_LOCK(m_lock);
     MMKVInfo("prepare to trim %s", m_mmapID.c_str());
 
+    SCOPED_LOCK(m_exclusiveProcessLock);
     checkLoadData();
     if (!isFileValid()) {
         MMKVWarning("[%s] file not valid", m_mmapID.c_str());
@@ -1400,7 +1401,6 @@ void MMKV::trim() {
     } else if (m_file->getFileSize() <= m_expectedCapacity) {
         return;
     }
-    SCOPED_LOCK(m_exclusiveProcessLock);
 
     fullWriteback();
     auto oldSize = m_file->getFileSize();


### PR DESCRIPTION
Fix sigbus issue when multiple processes simultaneously trim() by placing process locks before checkLoadData().