### PR TITLE
feat: Also expose C++ `set`, `getBytes`, `getVector` methods

### DIFF
--- a/Core/MMKV.h
+++ b/Core/MMKV.h
@@ -280,7 +280,8 @@ public:
     bool set(NSObject<NSCoding> *__unsafe_unretained obj, MMKVKey_t key, uint32_t expireDuration);
 
     NSObject *getObject(MMKVKey_t key, Class cls);
-#else  // !defined(MMKV_APPLE)
+#endif // MMKV_APPLE
+
     bool set(const char *value, MMKVKey_t key);
     bool set(const char *value, MMKVKey_t key, uint32_t expireDuration);
 
@@ -301,7 +302,6 @@ public:
     bool getBytes(MMKVKey_t key, mmkv::MMBuffer &result);
 
     bool getVector(MMKVKey_t key, std::vector<std::string> &result);
-#endif // MMKV_APPLE
 
     bool getBool(MMKVKey_t key, bool defaultValue = false, MMKV_OUT bool *hasValue = nullptr);
 
@@ -462,5 +462,5 @@ public:
 
 MMKV_NAMESPACE_END
 
-#endif
+#endif // __cplusplus
 #endif // MMKV_MMKV_H


### PR DESCRIPTION
Also exposes these methods to Apple Platforms:

```cpp
    bool set(const char *value, MMKVKey_t key);
    bool set(const char *value, MMKVKey_t key, uint32_t expireDuration);

    bool set(const std::string &value, MMKVKey_t key);
    bool set(const std::string &value, MMKVKey_t key, uint32_t expireDuration);

    bool set(const mmkv::MMBuffer &value, MMKVKey_t key);
    bool set(const mmkv::MMBuffer &value, MMKVKey_t key, uint32_t expireDuration);

    bool set(const std::vector<std::string> &vector, MMKVKey_t key);
    bool set(const std::vector<std::string> &vector, MMKVKey_t key, uint32_t expireDuration);

    // inplaceModification is recommended for faster speed
    bool getString(MMKVKey_t key, std::string &result, bool inplaceModification = true);

    mmkv::MMBuffer getBytes(MMKVKey_t key);

    bool getBytes(MMKVKey_t key, mmkv::MMBuffer &result);

    bool getVector(MMKVKey_t key, std::vector<std::string> &result);
```

Previously, those methods were hidden under a `#ifdef APPLE` / `#else` branch, so that on Apple you could only use the `NSObject<NSCoding>` classes.

In my C++ environment (where I already had strings), it was a redundant extra step to convert from `std::string` <> `NSString`, and from `MMBuffer` <> `NSData`, so this PR removes that intermediate conversion step.

Unfortunately I couldn't do the same thing for `allKeys`, as only the return type changes (`NSArray*` vs `std::vector<std::string>`), so it cannot be overloaded.

We _could_ introduce an additional method that is available whether MMKV_APPLE is true or not, but that's up to you if you want to do that @lingol.