### PR TITLE
fix: `uintX_t` is not defined when using gcc 13.2.1

### DIFF
--- a/Core/MemoryFile.h
+++ b/Core/MemoryFile.h
@@ -23,6 +23,7 @@
 #ifdef __cplusplus
 
 #include "MMKVPredef.h"
+#include <cstdint>
 #include <functional>
 
 #ifdef MMKV_ANDROID

--- a/Core/aes/AESCrypt.h
+++ b/Core/aes/AESCrypt.h
@@ -24,6 +24,7 @@
 
 #include "../MMKVPredef.h"
 #include <cstddef>
+#include <cstdint>
 
 #ifdef MMKV_DISABLE_CRYPT
 

--- a/Core/aes/openssl/openssl_aes.h
+++ b/Core/aes/openssl/openssl_aes.h
@@ -13,6 +13,7 @@
 
 #include "openssl_opensslconf.h"
 #include "openssl_arm_arch.h"
+#include <cstdint>
 #include <stddef.h>
 #include "../../MMKVPredef.h"
 


### PR DESCRIPTION
BTW, maybe IWYU should be used to prevent such problems.

See also:
- https://include-what-you-use.org/ (Official) 
- https://alampy.com/2024/03/30/cpp-iwyu-linter/ (A brief introduction in CN)