### PR TITLE
Fixed compilation errors

### DIFF
--- a/Core/core.vcxproj
+++ b/Core/core.vcxproj
@@ -156,7 +156,7 @@
       <AdditionalOptions>%(AdditionalOptions) /machine:X86</AdditionalOptions>
     </Lib>
     <PostBuildEvent>
-      <Command>for %%f in ("$(ProjectDir)MMKV.h", "$(ProjectDir)MMBuffer.h",  "$(ProjectDir)MMKVPredef.h") do xcopy /y /i %%f "$(OutDir)\include\MMKV\"</Command>
+      <Command>for %%f in ("$(ProjectDir)MMKV.h", "$(ProjectDir)MMBuffer.h",  "$(ProjectDir)MMKVPredef.h", "$(ProjectDir)MiniPBCoder.h") do xcopy /y /i %%f "$(OutDir)\include\MMKV\"</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Copying Headers</Message>
@@ -196,7 +196,7 @@
       <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
     </Lib>
     <PostBuildEvent>
-      <Command>for %%f in ("$(ProjectDir)MMKV.h", "$(ProjectDir)MMBuffer.h",  "$(ProjectDir)MMKVPredef.h") do xcopy /y /i %%f "$(OutDir)\include\MMKV\"</Command>
+      <Command>for %%f in ("$(ProjectDir)MMKV.h", "$(ProjectDir)MMBuffer.h",  "$(ProjectDir)MMKVPredef.h", "$(ProjectDir)MiniPBCoder.h") do xcopy /y /i %%f "$(OutDir)\include\MMKV\"</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Copying Headers</Message>
@@ -236,7 +236,7 @@
       <AdditionalOptions>%(AdditionalOptions) /machine:X86</AdditionalOptions>
     </Lib>
     <PostBuildEvent>
-      <Command>for %%f in ("$(ProjectDir)MMKV.h", "$(ProjectDir)MMBuffer.h",  "$(ProjectDir)MMKVPredef.h") do xcopy /y /i %%f "$(OutDir)\include\MMKV\"</Command>
+      <Command>for %%f in ("$(ProjectDir)MMKV.h", "$(ProjectDir)MMBuffer.h",  "$(ProjectDir)MMKVPredef.h", "$(ProjectDir)MiniPBCoder.h") do xcopy /y /i %%f "$(OutDir)\include\MMKV\"</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Copying Headers</Message>
@@ -276,7 +276,7 @@
       <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
     </Lib>
     <PostBuildEvent>
-      <Command>for %%f in ("$(ProjectDir)MMKV.h", "$(ProjectDir)MMBuffer.h",  "$(ProjectDir)MMKVPredef.h") do xcopy /y /i %%f "$(OutDir)\include\MMKV\"</Command>
+      <Command>for %%f in ("$(ProjectDir)MMKV.h", "$(ProjectDir)MMBuffer.h",  "$(ProjectDir)MMKVPredef.h", "$(ProjectDir)MiniPBCoder.h") do xcopy /y /i %%f "$(OutDir)\include\MMKV\"</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Copying Headers</Message>

--- a/Win32/Win32Demo/Win32Demo.vcxproj
+++ b/Win32/Win32Demo/Win32Demo.vcxproj
@@ -93,6 +93,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(OutDir)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -113,6 +114,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalIncludeDirectories>$(OutDir)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -134,6 +136,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(OutDir)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -158,6 +161,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <AdditionalIncludeDirectories>$(OutDir)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/Win32/Win32DemoProcess/Win32DemoProcess.vcxproj
+++ b/Win32/Win32DemoProcess/Win32DemoProcess.vcxproj
@@ -93,6 +93,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(OutDir)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -112,6 +113,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalIncludeDirectories>$(OutDir)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -133,6 +135,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(OutDir)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -156,6 +159,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <AdditionalIncludeDirectories>$(OutDir)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
Adding the missing header file MiniPBCoder.h. In order to use std::string_view in this library, we need to change the c++ standard to c++17.