### PR TITLE
feat: Create `MMKV::instanceExists(..)`

### DIFF
--- a/Core/MMKV.h
+++ b/Core/MMKV.h
@@ -529,6 +529,9 @@ public:
     // Note: the existing instance (if any) will be closed & destroyed
     static bool removeStorage(const std::string &mmapID, MMKVPath_t *relatePath = nullptr);
 
+    // check whether an instance with the given key exists or not
+    static bool instanceExists(const std::string &mmapID, MMKVPath_t *relatePath = nullptr);
+
     // just forbid it for possibly misuse
     explicit MMKV(const MMKV &other) = delete;
     MMKV &operator=(const MMKV &other) = delete;

--- a/Core/MMKV_IO.cpp
+++ b/Core/MMKV_IO.cpp
@@ -1517,7 +1517,7 @@ bool MMKV::isFileValid(const string &mmapID, MMKVPath_t *relatePath) {
     }
 }
 
-bool MMKV::instanceExists(const std::string &mmapID) {
+bool MMKV::instanceExists(const std::string &mmapID, MMKVPath_t *relatePath = nullptr) {
     auto mmapKey = mmapedKVKey(mmapID, relatePath);
 #ifdef MMKV_ANDROID
     auto &realID = mmapKey; // historically Android mistakenly use mmapKey as mmapID

--- a/Core/MMKV_IO.cpp
+++ b/Core/MMKV_IO.cpp
@@ -1517,6 +1517,30 @@ bool MMKV::isFileValid(const string &mmapID, MMKVPath_t *relatePath) {
     }
 }
 
+bool MMKV::instanceExists(const std::string &mmapID) {
+    auto mmapKey = mmapedKVKey(mmapID, relatePath);
+#ifdef MMKV_ANDROID
+    auto &realID = mmapKey; // historically Android mistakenly use mmapKey as mmapID
+#else
+    auto &realID = mmapID;
+#endif
+    MMKVDebug("mmapKey %s", mmapKey.c_str());
+
+    MMKVPath_t kvPath = mappedKVPathWithID(realID, MMKV_SINGLE_PROCESS, relatePath);
+    if (isFileExist(kvPath)) {
+        MMKVDebug("file exist (unencrypted) %s", kvPath.c_str());
+        return true;
+    }
+    MMKVPath_t crcPath = crcPathWithID(realID, MMKV_SINGLE_PROCESS, relatePath);
+    if (isFileExist(crcPath)) {
+        MMKVDebug("file exist (encrypted) %s", crcPath.c_str());
+        return true;
+    }
+
+    MMKVWarning("file does not exist %s", crcPath.c_str());
+    return false;
+}
+
 bool MMKV::removeStorage(const std::string &mmapID, MMKVPath_t *relatePath) {
     auto mmapKey = mmapedKVKey(mmapID, relatePath);
 #ifdef MMKV_ANDROID


### PR DESCRIPTION
Adds a static method to the C++ MMKV implementation that checks whether an instance with the given ID exists, or not.