### PR TITLE
Get current process name for AppStore review

### DIFF
--- a/Android/MMKV/mmkv/src/main/java/com/tencent/mmkv/MMKVContentProvider.java
+++ b/Android/MMKV/mmkv/src/main/java/com/tencent/mmkv/MMKVContentProvider.java
@@ -101,6 +101,9 @@ public class MMKVContentProvider extends ContentProvider {
     }
 
     protected static String getProcessNameByPID(@NonNull Context context, int pid) {
+        if (pid == android.os.Process.myPid()) {
+            return MMKVProcessUtil.getCurrentProcessName(context);
+        }
         ActivityManager manager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
         if (manager != null) {
             // clang-format off

--- a/Android/MMKV/mmkv/src/main/java/com/tencent/mmkv/MMKVProcessUtil.java
+++ b/Android/MMKV/mmkv/src/main/java/com/tencent/mmkv/MMKVProcessUtil.java
@@ -1,0 +1,80 @@
+package com.tencent.mmkv;
+
+import android.app.ActivityManager;
+import android.app.Application;
+import android.content.Context;
+import android.os.Build;
+import android.text.TextUtils;
+
+import androidx.annotation.NonNull;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+/**
+ * Get current process name for AppStore review
+ */
+class MMKVProcessUtil {
+
+    private static String currentProcessName = "";
+
+    public static String getCurrentProcessName(@NonNull Context context) {
+        if (!TextUtils.isEmpty(currentProcessName)) {
+            return currentProcessName;
+        }
+
+        currentProcessName = getCurrentProcessNameByApplication();
+        if (!TextUtils.isEmpty(currentProcessName)) {
+            return currentProcessName;
+        }
+
+        currentProcessName = getCurrentProcessNameByActivityThread();
+        if (!TextUtils.isEmpty(currentProcessName)) {
+            return currentProcessName;
+        }
+
+        currentProcessName = getCurrentProcessNameByActivityManager(context);
+        return currentProcessName;
+    }
+
+    @NonNull
+    private static String getCurrentProcessNameByApplication() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            return Application.getProcessName();
+        }
+        return "";
+    }
+
+    @NonNull
+    private static String getCurrentProcessNameByActivityThread() {
+        String processName = "";
+        try {
+            Method declaredMethod = Class.forName("android.app.ActivityThread").
+                    getDeclaredMethod("currentProcessName");
+            declaredMethod.setAccessible(true);
+            final Object invoke = declaredMethod.invoke(null);
+            if (invoke instanceof String) {
+                processName = (String) invoke;
+            }
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
+        return processName;
+    }
+
+    private static String getCurrentProcessNameByActivityManager(@NonNull Context context) {
+        int pid = android.os.Process.myPid();
+        ActivityManager am = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+        if (am != null) {
+            List<ActivityManager.RunningAppProcessInfo> runningAppList = am.getRunningAppProcesses();
+            if (runningAppList != null) {
+                for (ActivityManager.RunningAppProcessInfo processInfo : runningAppList) {
+                    if (processInfo.pid == pid) {
+                        return processInfo.processName;
+                    }
+                }
+            }
+        }
+        return "";
+    }
+}


### PR DESCRIPTION
ActivityManager.getRunningAppProcesses() 容易被应用商店合规判定为 非法获取其他进程信息，Android 9 以上Google已经提供了公开API来获取当前的进程名，不涉及任何违规问题，希望能合并下代码或者调整下mmkv中关于进程名获取的方式