### PR TITLE
fix: Replace `random` with `rand` on Win32

### DIFF
--- a/Core/aes/AESCrypt.cpp
+++ b/Core/aes/AESCrypt.cpp
@@ -109,7 +109,11 @@ uint32_t AESCrypt::randomItemSizeHolder(uint32_t size) {
     auto ItemSizeHolderMax = ItemSizeHolders[size] - 1;
 
     srand((unsigned) time(nullptr));
+#   ifdef _WIN32
+    auto result = static_cast<uint32_t>(rand());
+#   else
     auto result = static_cast<uint32_t>(random());
+#   endif
     result = result % (ItemSizeHolderMax - ItemSizeHolderMin + 1);
     result += ItemSizeHolderMin;
     return result;


### PR DESCRIPTION
Cause `random` function not in Standard `C`, so here I replace `random` with `rand` in Windows.