### PR TITLE
fix: missing `uint32_t` type

### DIFF
--- a/Core/crc32/Checksum.h
+++ b/Core/crc32/Checksum.h
@@ -23,6 +23,7 @@
 #ifdef __cplusplus
 
 #include "../MMKVPredef.h"
+#include <cstdint>
 
 #if MMKV_EMBED_ZLIB
 


### PR DESCRIPTION
On GNU 13.3.0, it failed to be compiled.

`uint32_t` is used here:
https://github.com/Tencent/MMKV/blob/5019dd894c5313bb3129a2c82afaf71e9c2fb3e8/Core/crc32/Checksum.h#L56