### PR TITLE
Mark the `rootProject` name for MMKV-Android

### DIFF
--- a/Android/MMKV/settings.gradle
+++ b/Android/MMKV/settings.gradle
@@ -1,1 +1,3 @@
+rootProject.name = "MMKV-Android"
+
 include ':mmkv', ':mmkvdemo', 'mmkvannotation'


### PR DESCRIPTION
This supports retaining both root MMKV and MMKV-Android projects in the recent projects in AS / IDEA.

<img width="872" alt="image" src="https://github.com/user-attachments/assets/27f8199f-83f9-480a-8601-bb73b2332ad1" />
