### PR TITLE
Fix Memory Leak in MMBuffer Destructor on Apple Platforms

### DIFF
--- a/Core/MMBuffer.cpp
+++ b/Core/MMBuffer.cpp
@@ -191,12 +191,17 @@ MMBuffer::~MMBuffer() {
         if (isNoCopy == MMBufferCopy) {
             [m_data release];
         }
-        return;
     }
 #endif
 
     if (isNoCopy == MMBufferCopy && ptr) {
+#ifdef MMKV_APPLE
+        if (!m_data || ptr != [m_data bytes]) {
+            free(ptr);
+        }
+#else
         free(ptr);
+#endif
     }
 }
 


### PR DESCRIPTION
# Fix Memory Leak in MMBuffer Destructor on Apple Platforms

## Summary
This PR addresses a memory leak in the `MMBuffer` destructor on Apple platforms. The issue arises when the destructor fails to clean up the `ptr` member after releasing associated `NSData` objects.

## Bug Description
On Apple platforms, the `MMBuffer` destructor prematurely exits after releasing `NSData` objects, leaving the `ptr` member unhandled. This results in memory leaks when `ptr` points to independently allocated memory.

## Affected Scenarios
- Instances where `MMBuffer` is created with `NSData` and the `MMBufferCopy` flag, resulting in a separate memory allocation.
- Cases where `ptr` is independently allocated, separate from the `NSData` buffer.
- Mixed initialization patterns involving both `m_data` and `ptr`.

## Testing
- Verified that the fix resolves memory leaks in scenarios with mixed memory allocations.
- Evaluated the changes across various initialization patterns.