### PR TITLE
Fix: incorrect return value when address converted to long exceeds Lo…

### DIFF
--- a/Android/MMKV/mmkv/src/main/java/com/tencent/mmkv/MMKV.java
+++ b/Android/MMKV/mmkv/src/main/java/com/tencent/mmkv/MMKV.java
@@ -1600,7 +1600,7 @@ public class MMKV implements SharedPreferences, SharedPreferences.Editor {
     @Nullable
     public static NativeBuffer createNativeBuffer(int size) {
         long pointer = createNB(size);
-        if (pointer <= 0) {
+        if (pointer == 0) {
             return null;
         }
         return new NativeBuffer(pointer, size);


### PR DESCRIPTION
Fix: incorrect return value when native address converted to long exceeds Long.MAX_VALUE. This fix ensures that high memory addresses are correctly interpreted in the Java layer, preventing negative values due to overflow.