### PR TITLE
fix: Make `MMKV` and `MMKVCore` define modules

### DIFF
--- a/MMKV.podspec
+++ b/MMKV.podspec
@@ -31,6 +31,7 @@ Pod::Spec.new do |s|
     "CLANG_CXX_LANGUAGE_STANDARD" => "gnu++20",
     "CLANG_CXX_LIBRARY" => "libc++",
     "CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF" => "NO",
+    "DEFINES_MODULE" => "YES",
   }
 
   s.dependency 'MMKVCore', '~> 2.2.3'

--- a/MMKVCore.podspec
+++ b/MMKVCore.podspec
@@ -36,6 +36,7 @@ Pod::Spec.new do |s|
     "CLANG_CXX_LANGUAGE_STANDARD" => "gnu++20",
     "CLANG_CXX_LIBRARY" => "libc++",
     "CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF" => "NO",
+    "DEFINES_MODULE" => "YES",
     'RELEASE' => {
       'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) NDEBUG=1'
     }


### PR DESCRIPTION
This is needed to use MMKV and MMKVCore in Swift pods. 

I use this for the new react-native-mmkv version, which contains Swift code (bridged via [nitro](https://github.com/mrousavy/nitro))

Rebased version of #1577 to use the `dev` branch instead of `main`.