### PR TITLE
Remove explicit dynamic type declaration for MMKVAppExtension library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     ],
     products: [
         .library(name: "MMKV", targets: ["MMKV"]),
-        .library(name: "MMKVAppExtension", type: .dynamic, targets: ["MMKVAppExtension"]),
+        .library(name: "MMKVAppExtension", targets: ["MMKVAppExtension"]),
         .library(name: "MMKVCore", type: .static, targets: ["MMKVCore"]),
     ],
     targets: [


### PR DESCRIPTION
This PR removes the explicit `.dynamic` type declaration for the `MMKVAppExtension` library in `Package.swift`.

As detailed in my comment on #535, forcing `MMKVAppExtension` to be a dynamic library causes several linking crashes, duplicate symbol warnings, and App Store validation failures (`Invalid Bundle`) when integrating MMKV into both a main app and a widget extension via SPM. 

Allowing SPM to link it statically resolves all of these issues seamlessly. 

For the full context, error logs, and the troubleshooting process, please see my comment here:
https://github.com/Tencent/MMKV/issues/535#issuecomment-4017976689