### PR TITLE
Add static library option for MMKVAppExtension in SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,7 @@ let package = Package(
     products: [
         .library(name: "MMKV", targets: ["MMKV"]),
         .library(name: "MMKVAppExtension", type: .dynamic, targets: ["MMKVAppExtension"]),
+        .library(name: "MMKVAppExtension-static", type: .static, targets: ["MMKVAppExtension"]),
         .library(name: "MMKVCore", type: .static, targets: ["MMKVCore"]),
     ],
     targets: [


### PR DESCRIPTION
This PR adds a static library target (MMKVAppExtension-static) to Package.swift

Using a static library makes quick integration easier. We don't need to worry about code signing and framework embed issues.

Thanks