### PR TITLE
Fix POSIX build with incomplete MMBuffer type (Update PBUtility.h)

### DIFF
--- a/Core/PBUtility.h
+++ b/Core/PBUtility.h
@@ -23,6 +23,7 @@
 #ifdef  __cplusplus
 
 #include "MMKVPredef.h"
+#include "MMBuffer.h"
 
 #include <cstdint>
 


### PR DESCRIPTION
# Fix POSIX build on Linux / 修复 Linux POSIX 构建问题

## English

### Problem

The POSIX build fails when compiling `PBUtility.cpp` because `PBUtility.h` uses `MMBuffer::length()` while only a forward declaration of `MMBuffer` is available.

The compiler reports:

```text
error: invalid use of incomplete type 'const class mmkv::MMBuffer'
```

### Fix

Include `MMBuffer.h` from `PBUtility.h` so that the complete definition of `MMBuffer` is available when `MMBuffer::length()` is used.

### Testing

Tested on Fedora Linux with GCC 16.1.1:

```bash
cmake -S POSIX/src -B build
cmake --build build -j16
```

The POSIX build now completes successfully.

---

## 中文

### 问题

在 Linux 上编译 POSIX 版本时，编译 `PBUtility.cpp` 会失败。

`PBUtility.h` 中使用了 `MMBuffer::length()`，但是当前只包含了 `MMBuffer` 的前置声明，因此编译器无法使用 `MMBuffer` 的成员函数。

编译器报错：

```text
error: invalid use of incomplete type 'const class mmkv::MMBuffer'
```

### 修复

在 `PBUtility.h` 中包含 `MMBuffer.h`，确保使用 `MMBuffer::length()` 时能够获得 `MMBuffer` 的完整类型定义。

### 测试

在 Fedora Linux 和 GCC 16.1.1 环境下测试：

```bash
cmake -S POSIX/src -B build
cmake --build build -j16
```

POSIX 版本现在可以正常完成编译。