### PR TITLE
fix(android): guard onDetachedFromEngine NPE when libmmkv.so missing for ABI

### DIFF
--- a/flutter/mmkv_android/android/src/main/java/com/tencent/mmkv/MMKVPlugin.java
+++ b/flutter/mmkv_android/android/src/main/java/com/tencent/mmkv/MMKVPlugin.java
@@ -39,7 +39,16 @@ public class MMKVPlugin implements FlutterPlugin, MethodCallHandler {
 
     @Override
     public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
-        loadLibrary();
+        // The published `com.tencent:mmkv` AAR ships native libs for arm64-v8a
+        // and x86_64 only. On an armeabi-v7a / x86 device `System.loadLibrary`
+        // throws UnsatisfiedLinkError here; without this guard `channel` is
+        // never assigned and onDetachedFromEngine() then NPEs on activity
+        // destroy ("Unable to destroy activity"), a fatal crash on every exit.
+        try {
+            loadLibrary();
+        } catch (UnsatisfiedLinkError e) {
+            android.util.Log.w("MMKVPlugin", "libmmkv.so not available for this ABI; MMKV disabled", e);
+        }
 
         context = flutterPluginBinding.getApplicationContext();
         channel = new MethodChannel(flutterPluginBinding.getBinaryMessenger(), "mmkv");
@@ -68,7 +77,10 @@ public class MMKVPlugin implements FlutterPlugin, MethodCallHandler {
 
     @Override
     public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
-        channel.setMethodCallHandler(null);
+        if (channel != null) {
+            channel.setMethodCallHandler(null);
+            channel = null;
+        }
     }
 
     private static boolean isLibraryLoaded = false;


### PR DESCRIPTION
### Problem

The published `com.tencent:mmkv` AAR ships native libs for `arm64-v8a` and
`x86_64` only — there is no `libmmkv.so` for `armeabi-v7a` or `x86`.

On a 32-bit-only device:

1. `MMKVPlugin.onAttachedToEngine()` calls `loadLibrary()` →
   `System.loadLibrary("mmkv")` throws `UnsatisfiedLinkError` **before**
   `channel` is assigned.
2. The Flutter engine swallows the attach-time throw and keeps running.
3. On activity destroy, `FlutterEngineConnectionRegistry.removeAll()` calls
   `onDetachedFromEngine()` unconditionally → `channel.setMethodCallHandler(null)`
   → `NullPointerException` → `RuntimeException: Unable to destroy activity`
   → **fatal crash on every app exit** for that whole ABI class.

Crash signature:

java.lang.RuntimeException: Unable to destroy activity ...
Caused by: java.lang.NullPointerException:
    at com.tencent.mmkv.MMKVPlugin.onDetachedFromEngine(MMKVPlugin.java:71)
    at io.flutter.embedding.engine.FlutterEngineConnectionRegistry.removeAll(...)

### Fix

- Catch the load failure in `onAttachedToEngine()` so `channel` is still
  registered. MMKV method calls then fail gracefully through the existing FFI
  path (`DynamicLibrary.open("libmmkv.so")` already throws on these ABIs).
- Null-guard `onDetachedFromEngine()`.

No behaviour change on `arm64-v8a` / `x86_64`. On an ABI without the native
lib, MMKV is simply inert instead of crashing the host app on exit.